### PR TITLE
feat(whatsnew): Add "what's new" page to docs 

### DIFF
--- a/sites/reactflow.dev/src/pages/_meta.json
+++ b/sites/reactflow.dev/src/pages/_meta.json
@@ -52,6 +52,13 @@
       "layout": "raw"
     }
   },
+  "whats-new": {
+    "title": "What's new?",
+    "display": "hidden",
+    "theme": {
+      "layout": "default"
+    }
+  },
   "404": {
     "title": "404",
     "theme": {

--- a/sites/reactflow.dev/src/pages/whats-new.mdx
+++ b/sites/reactflow.dev/src/pages/whats-new.mdx
@@ -1,0 +1,3 @@
+# What's New?
+
+## Some Content

--- a/sites/reactflow.dev/src/pages/whats-new.mdx
+++ b/sites/reactflow.dev/src/pages/whats-new.mdx
@@ -2,7 +2,7 @@
 
 We refreshed the React Flow docs in November 2023, so things might look a little different around here:
 
-**Docs is now called [Learn](learn)**. This section aims to answer the question of "how do I use X?"
+**Docs is now called [Learn](/learn)**. This section aims to answer the question of "how do I use X?"
 
 **API is now called [Reference](/api-reference)**. This section answers the question "what is this thing?" A big change from the previous version of our docs is that all of our types, components, hooks, and util functions now get their own page now.
 

--- a/sites/reactflow.dev/src/pages/whats-new.mdx
+++ b/sites/reactflow.dev/src/pages/whats-new.mdx
@@ -1,15 +1,17 @@
 # What's New?
 
-We refreshed the React Flow docs in November 2023, so things are arranged a little differently:
+We refreshed the React Flow docs in November 2023, so things might look a little different around here:
 
-"Docs" is now **[Learn](learn)**
+**Docs is now called [Learn](learn)**. This section aims to answer the question of "how do I use X?"
 
-"API" is now **[Reference](/api-reference)**
+**API is now called [Reference](/api-reference)**. This section answers the question "what is this thing?" A big change from the previous version of our docs is that all of our types, components, hooks, and util functions now get their own page now.
 
-"How to" blog posts are now in **Learn > [Tutorials](/learn/tutorials)**
+"How to" blog posts now live in **Learn > [Tutorials](/learn/tutorials)**
 
 ## Why the changes?
 
-So far the docs have been growing organically since 2019, which made them a bit of a mess. While we worked on a website redesign, we decided it was time to rethink the concept of our docs to create a better developer experience. So we hope that things become a bit easier to find for both experienced React Flow users and newcomers.
+So far the docs have been growing organically since 2019, without any sort of overarching concept. While we worked on a website redesign, we decided it was time to rethink how folks are using our docs so that we can create a better developer experience. Our hope is that these changes make the docs easier to use for both experienced React Flow users and newcomers.
 
-We also did a change of tech stack along the way. We were using Docusaurus in our old documentation, and now we're using Nextra. Cool beans.
+We also did a change of tech stack along the way. We were using Docusaurus, and now we're using [Nextra](https://nextra.site/). Cool beans.
+
+If you find anything to change or improve, just click on the "Edit this page" link on the right-side of any page in our docs.

--- a/sites/reactflow.dev/src/pages/whats-new.mdx
+++ b/sites/reactflow.dev/src/pages/whats-new.mdx
@@ -8,7 +8,7 @@ We refreshed the React Flow docs in November 2023, so things are arranged a litt
 
 "How to" blog posts are now in **Learn > [Tutorials](/learn/tutorials)**
 
-## Why?
+## Why the changes?
 
 So far the docs have been growing organically since 2019, which made them a bit of a mess. While we worked on a website redesign, we decided it was time to rethink the concept of our docs to create a better developer experience. So we hope that things become a bit easier to find for both experienced React Flow users and newcomers.
 

--- a/sites/reactflow.dev/src/pages/whats-new.mdx
+++ b/sites/reactflow.dev/src/pages/whats-new.mdx
@@ -1,3 +1,15 @@
 # What's New?
 
-## Some Content
+We refreshed the React Flow docs in November 2023, so things are arranged a little differently:
+
+"Docs" is now **[Learn](learn)**
+
+"API" is now **[Reference](/api-reference)**
+
+"How to" blog posts are now in **Learn > [Tutorials](/learn/tutorials)**
+
+## Why?
+
+So far the docs have been growing organically since 2019, which made them a bit of a mess. While we worked on a website redesign, we decided it was time to rethink the concept of our docs to create a better developer experience. So we hope that things become a bit easier to find for both experienced React Flow users and newcomers.
+
+We also did a change of tech stack along the way. We were using Docusaurus in our old documentation, and now we're using Nextra. Cool beans.

--- a/sites/reactflow.dev/theme.config.tsx
+++ b/sites/reactflow.dev/theme.config.tsx
@@ -141,7 +141,7 @@ export default {
         href="/whats-new"
         className="nx-text-xs nx-font-medium nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-100 contrast-more:nx-text-gray-800 contrast-more:dark:nx-text-gray-50"
       >
-        What's new?
+        New in React Flow Docs
       </Link>
     ),
   },

--- a/sites/reactflow.dev/theme.config.tsx
+++ b/sites/reactflow.dev/theme.config.tsx
@@ -135,6 +135,16 @@ export default {
       return <Search {...props} />;
     },
   },
+  toc: {
+    extraContent: () => (
+      <Link
+        href="/whats-new"
+        className="nx-text-xs nx-font-medium nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-100 contrast-more:nx-text-gray-800 contrast-more:dark:nx-text-gray-50"
+      >
+        What's new?
+      </Link>
+    ),
+  },
   feedback: {
     useLink: () => 'https://xyflow.com/contact',
   },

--- a/sites/reactflow.dev/theme.config.tsx
+++ b/sites/reactflow.dev/theme.config.tsx
@@ -141,7 +141,7 @@ export default {
         href="/whats-new"
         className="nx-text-xs nx-font-medium nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-100 contrast-more:nx-text-gray-800 contrast-more:dark:nx-text-gray-50"
       >
-        New in React Flow Docs
+        What's new here?
       </Link>
     ),
   },


### PR DESCRIPTION
Adding a page to docs as a reference for long-time users of the React Flow docs to know what changed