### PR TITLE
typo: pnpm and yarn instructions were inverted

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/advanced-use/state-management.mdx
+++ b/sites/reactflow.dev/src/pages/learn/advanced-use/state-management.mdx
@@ -35,14 +35,14 @@ npm install --save zustand
   <Tab>
 
 ```bash copy
-yarn add zustand
+pnpm add zustand
 ```
 
   </Tab>
     <Tab>
 
 ```bash copy
-pnpm add zustand
+yarn add zustand
 ```
 
   </Tab>


### PR DESCRIPTION
Install command for Zustand was inverted 

![image](https://github.com/xyflow/web/assets/4257500/26f8676b-cc8e-4ffa-9c35-29b83a0bf7cb)
