### PR TITLE
fix(svelte-examples) Make easy-connect label reactive

### DIFF
--- a/apps/svelte-examples/src/routes/examples/nodes/easy-connect/CustomNode.svelte
+++ b/apps/svelte-examples/src/routes/examples/nodes/easy-connect/CustomNode.svelte
@@ -15,7 +15,7 @@
   $: isConnecting = !!$connection.startHandle?.nodeId;
   $: isTarget = !!$connection.startHandle && $connection.startHandle?.nodeId !== id;
 
-  const label = isTarget ? 'Drop here' : 'Drag to connect';
+  $: label = isTarget ? 'Drop here' : 'Drag to connect';
 </script>
 
 <div class="customNode">


### PR DESCRIPTION
Fixes a bug from [porting](https://github.com/xyflow/web/pull/67) over the React examples. The node labels were not updated when you started to drag a new connection out.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/xyflow/web/assets/16587643/a9fc722c-6a06-4753-a932-58c421f86365) | ![image](https://github.com/xyflow/web/assets/16587643/33345343-ef43-4487-ad94-882d0446b56f) |