### PR TITLE
Removing "selectable" field from Edge API docs

### DIFF
--- a/sites/reactflow.dev/src/page-data/reference/types/Edge.fields.ts
+++ b/sites/reactflow.dev/src/page-data/reference/types/Edge.fields.ts
@@ -17,7 +17,6 @@ export const defaultEdgeFields: PropsTableProps = {
     { name: 'animated', type: 'boolean' },
     { name: 'selected', type: 'boolean' },
     { name: 'deletable', type: 'boolean' },
-    { name: 'selectable', type: 'boolean' },
     { name: 'focusable', type: 'boolean' },
     { name: 'updatable?', type: 'boolean | "source" | "target"' },
     { name: 'markerStart', type: 'string | EdgeMarker' },


### PR DESCRIPTION
I don't know if this field was deprecated or removed or other. When I try to use this field in my project, there is no "selectable" field on a `FlowEdge`.

The codebase also mentions "selectable" in a few other places, so if this change is valid, I don't know if other places need to be updated as well.