### PR TITLE
Fix Preventing Cycles example node cycle itself

### DIFF
--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/PreventConnectionCycles/index.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/PreventConnectionCycles/index.js
@@ -27,6 +27,7 @@ const Flow = () => {
         }
       };
 
+      if (target.id === connection.source) return false;
       return !hasCycle(target);
     },
     [nodes, edges],


### PR DESCRIPTION
Scope: "Preventing Cycles" example.
Issue:
With the current `isValidConnection` implementation it's still possible to cycle the node to itself.
This happens because `hasCycle` function assertions begin from the **outgoer** nodes only, skipping the initial one.

![image](https://github.com/xyflow/web/assets/1101526/eeb90fdc-9aa4-49d5-8980-7979023e3448)
