### PR TITLE
fix AddNodeOnEdgeDrop to support offset handles

### DIFF
--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/AddNodeOnEdgeDrop/index.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/AddNodeOnEdgeDrop/index.js
@@ -29,7 +29,11 @@ const AddNodeOnEdgeDrop = () => {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const { screenToFlowPosition } = useReactFlow();
   const onConnect = useCallback(
-    (params) => setEdges((eds) => addEdge(params, eds)),
+    (params) => {
+      // reset the start node on connections
+      connectingNodeId.current = null;
+      setEdges((eds) => addEdge(params, eds))
+    },
     [],
   );
 
@@ -39,6 +43,8 @@ const AddNodeOnEdgeDrop = () => {
 
   const onConnectEnd = useCallback(
     (event) => {
+      if (!connectingNodeId.current) return;
+
       const targetIsPane = event.target.classList.contains('react-flow__pane');
 
       if (targetIsPane) {


### PR DESCRIPTION
The [Add Node On Edge Drop example](https://reactflow.dev/examples/nodes/add-node-on-edge-drop) does not respect the offset/bufferzone when connecting to existing nodes.

Fixed by resetting the ref to the started node when a full connect happens, this now supports offsetting handles, where the user doesn't need be directly on a handle to connect, where thus the cursor is detected as "on the pane".

Error in demo:

https://github.com/xyflow/web/assets/7737034/05cbd750-c8d3-4484-a6b2-1b113fa6efe3



Fixed version:


https://github.com/xyflow/web/assets/7737034/31330cdb-9559-437b-a0de-a089c5fc4ff2



