### PR TITLE
Typo fix in docs, in Custom Edge section.

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/customization/custom-edges.mdx
+++ b/sites/reactflow.dev/src/pages/learn/customization/custom-edges.mdx
@@ -123,7 +123,7 @@ export default function CustomEdge({ id, sourceX, sourceY, targetX, targetY }) {
       <BaseEdge id={id} path={edgePath} />
       <EdgeLabelRenderer>
         <button
-          onClick={() => setEdge((edges) => edges.filter((e) => e.id !== id))}
+          onClick={() => setEdges((edges) => edges.filter((e) => e.id !== id))}
         >
           delete
         </button>


### PR DESCRIPTION
Typo in the code example for creating delete button in custom edge. The example shows setting new edges without the deleted one, but the function name is missing letter. setEdge(...) -> setEdges(...)