### PR TITLE
chore(reactflow): add missing `onSelectionContextMenu` type reference

### DIFF
--- a/sites/reactflow.dev/src/page-data/reference/ReactFlow.props.ts
+++ b/sites/reactflow.dev/src/page-data/reference/ReactFlow.props.ts
@@ -421,7 +421,7 @@ export const selectionEventHandlerProps: PropsTableProps = {
     },
     { name: 'onSelectionStart', type: '() => void' },
     { name: 'onSelectionEnd', type: '() => void' },
-    { name: 'onSelectionContextMenu', type: '(event: ReactMouseEvent, nodes: Node[]) => void' },
+    { name: 'onSelectionContextMenu', type: '(event: React.MouseEvent, nodes: Node[]) => void' },
   ],
 };
 

--- a/sites/reactflow.dev/src/page-data/reference/ReactFlow.props.ts
+++ b/sites/reactflow.dev/src/page-data/reference/ReactFlow.props.ts
@@ -421,6 +421,7 @@ export const selectionEventHandlerProps: PropsTableProps = {
     },
     { name: 'onSelectionStart', type: '() => void' },
     { name: 'onSelectionEnd', type: '() => void' },
+    { name: 'onSelectionContextMenu', type: '(event: ReactMouseEvent, nodes: Node[]) => void' },
   ],
 };
 


### PR DESCRIPTION
# What's Changed?

- Add missing `onSelectionContextMenu` type reference to `ReactFlow.props.ts`