### PR TITLE
fixed typo on background example

### DIFF
--- a/sites/svelteflow.dev/src/pages/api-reference/components/background.mdx
+++ b/sites/svelteflow.dev/src/pages/api-reference/components/background.mdx
@@ -28,7 +28,7 @@ backgrounds common in node-based UIs. It comes with three variants: `lines`,
 </script>
 
 <SvelteFlow nodes={nodes} edges={edges}>
-  <Background color="#ccc" variant={BackgroundVariant.Dots} />
+  <Background bgColor="#ccc" variant={BackgroundVariant.Dots} />
 </SvelteFlow>
 ```
 


### PR DESCRIPTION
Fixed typo in [background example](https://svelteflow.dev/api-reference/components/background) where color prop should be bgColor