### PR TITLE
fix(docs): remove suggestion of libavoid for edge routing

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/layouting/layouting.mdx
+++ b/sites/reactflow.dev/src/pages/learn/layouting/layouting.mdx
@@ -223,8 +223,6 @@ resources we thought looked promising:
 
 - [react-flow-smart-edge](https://github.com/tisoap/react-flow-smart-edge)
 - [Routing Orthogonal Diagram Connectors in JavaScript](https://medium.com/swlh/routing-orthogonal-diagram-connectors-in-javascript-191dc2c5ff70)
-- [elkjs](https://github.com/kieler/elkjs) (again!) has some algorithms just for
-  edge routing, such as [libavoid](https://eclipse.dev/elk/reference/algorithms/org-eclipse-elk-alg-libavoid.html).
 
 If you do explore some custom edge routing options, consider contributing back to
 the community by writing a blog post or creating a library!


### PR DESCRIPTION
The Layouting docs currently suggest that elkjs supports libavoid as an edge routing solution. While ELK (the Java version with all the docs) supports libavoid, it's not supported by elkjs (as of yet); see https://github.com/kieler/elkjs/issues/210.

This PR removes the link to elkjs and libavoid in the edge routing section since it can easily be confusing and take some time to figure out why libavoid isn't working with elkjs.