### PR TITLE
✨ Add a guide for drawing multiple connection lines.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,11 +49,8 @@ importers:
         specifier: ^0.155.1
         version: 0.155.1
       '@xyflow/svelte':
-        specifier: 0.0.33
-        version: 0.0.33(svelte@4.2.9)
-      '@xyflow/system':
-        specifier: ^0.0.14
-        version: 0.0.14
+        specifier: 0.0.34
+        version: 0.0.34(svelte@4.2.9)
       elkjs:
         specifier: ^0.8.2
         version: 0.8.2
@@ -6907,19 +6904,31 @@ packages:
       svelte: 4.2.9
     dev: true
 
-  /@xyflow/svelte@0.0.33(svelte@4.2.9):
-    resolution: {integrity: sha512-GBMnkF5AvMwH/NyhhlZWJw5DJn/IyW7s22cEk87UBjtiNLd02GKGrvDBLeWmWMj2QbEQjn3O30o84TXwwXuZyA==}
+  /@xyflow/svelte@0.0.34(svelte@4.2.9):
+    resolution: {integrity: sha512-3uo9V06BOVoSp0Yrpe48j6m12llRGqjE3KXhkU8m4Kn6dVlWBVnEbmLUKU9CLjfhjZei1C9sy5PbL5YzbZ4ymQ==}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0
     dependencies:
       '@svelte-put/shortcut': 3.1.0
-      '@xyflow/system': 0.0.14
+      '@xyflow/system': 0.0.15
       classcat: 5.0.4
       svelte: 4.2.9
     dev: false
 
   /@xyflow/system@0.0.14:
     resolution: {integrity: sha512-dmVQujAwZyoSZTr0sQHlgro9pS+RO9AgjT2BDlyB7t/+FYQBgW3FKdTQnVh8/azcdAncWruyiPt9K/h2kpTYrA==}
+    dependencies:
+      '@types/d3': 7.4.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.10
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+    dev: false
+
+  /@xyflow/system@0.0.15:
+    resolution: {integrity: sha512-TD3+lm4H1CtDgzooDv9K8izG49RzfpMklIyiQ84ftF3HgwhjPY8oR8pf0L7f6i+sTeCyIL1V+P4kM1GJc0ZN3w==}
     dependencies:
       '@types/d3': 7.4.3
       '@types/d3-drag': 3.0.7

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/ConnectionLine.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/ConnectionLine.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { useStore, internalsSymbol, getSimpleBezierPath } from 'reactflow';
+import { internalsSymbol, getSimpleBezierPath, useNodes } from 'reactflow';
 
 export default ({ fromNode, toX, toY }) => {
-  const { nodeInternals } = useStore();
-  const handleBounds = [...nodeInternals.values()].flatMap((node) => {
+  const handleBounds = useNodes().flatMap((node) => {
     if (node.id !== fromNode.id && !node.selected) return [];
 
     return node[internalsSymbol].handleBounds.source.map((bounds) => ({

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/ConnectionLine.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/ConnectionLine.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useStore, internalsSymbol, getSimpleBezierPath } from 'reactflow';
+
+export default ({ fromNode, toX, toY }) => {
+  const { nodeInternals } = useStore();
+  const handleBounds = [...nodeInternals.values()].flatMap((node) => {
+    if (node.id !== fromNode.id && !node.selected) return [];
+
+    return node[internalsSymbol].handleBounds.source.map((bounds) => ({
+      id: node.id,
+      positionAbsolute: node.positionAbsolute,
+      bounds,
+    }));
+  });
+
+  return handleBounds.map(({ id, positionAbsolute, bounds }) => {
+    const fromHandleX = bounds.x + bounds.width / 2;
+    const fromHandleY = bounds.y + bounds.height / 2;
+    const fromX = positionAbsolute.x + fromHandleX;
+    const fromY = positionAbsolute.y + fromHandleY;
+    const [d] = getSimpleBezierPath({
+      sourceX: fromX,
+      sourceY: fromY,
+      targetX: toX,
+      targetY: toY,
+    });
+
+    return (
+      <g key={`${id}-${bounds.id}`}>
+        <path fill="none" strokeWidth={1.5} stroke="black" d={d} />
+        <circle
+          cx={toX}
+          cy={toY}
+          fill="#fff"
+          r={3}
+          stroke="black"
+          strokeWidth={1.5}
+        />
+      </g>
+    );
+  });
+};

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/index.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/index.js
@@ -25,13 +25,13 @@ const initialNodes = [
   {
     id: 'c',
     type: 'input',
-    data: { label: 'nodes' },
+    data: { label: 'nodes...' },
     position: { x: 150, y: 0 },
   },
   {
     id: 'd',
     type: 'output',
-    data: { label: 'D' },
+    data: { label: '...and connect to me!' },
     position: { x: 250, y: 200 },
   },
 ];

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/index.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/MultiConnectionLine/index.js
@@ -1,0 +1,72 @@
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  useNodesState,
+  useEdgesState,
+  addEdge,
+  Background,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+import ConnectionLine from './ConnectionLine';
+
+const initialNodes = [
+  {
+    id: 'a',
+    type: 'input',
+    data: { label: 'Select' },
+    position: { x: 100, y: -100 },
+  },
+  {
+    id: 'b',
+    type: 'input',
+    data: { label: 'these' },
+    position: { x: 300, y: -50 },
+  },
+  {
+    id: 'c',
+    type: 'input',
+    data: { label: 'nodes' },
+    position: { x: 150, y: 0 },
+  },
+  {
+    id: 'd',
+    type: 'output',
+    data: { label: 'D' },
+    position: { x: 250, y: 200 },
+  },
+];
+
+const ConnectionLineFlow = () => {
+  const [nodes, _, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const onConnect = useCallback(
+    ({ source, target }) => {
+      return setEdges((eds) =>
+        nodes
+          .filter((node) => node.id === source || node.selected)
+          .reduce(
+            (eds, node) => addEdge({ source: node.id, target }, eds),
+            eds,
+          ),
+      );
+    },
+    [nodes],
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      connectionLineComponent={ConnectionLine}
+      onConnect={onConnect}
+      fitView
+      fitViewOptions={{
+        padding: 0.2,
+      }}
+    />
+  );
+};
+
+export default ConnectionLineFlow;

--- a/sites/reactflow.dev/src/pages/examples/edges/_meta.json
+++ b/sites/reactflow.dev/src/pages/examples/edges/_meta.json
@@ -3,6 +3,7 @@
   "edge-types": "Edge Types",
   "updatable-edge": "Updatable Edge",
   "custom-connectionline": "Connection Line",
+  "multi-connection-line": "Multi Connection Line",
   "markers": "Edge Markers",
   "delete-edge-on-drop": "Delete Edge on Drop",
   "floating-edges": "Floating Edges",

--- a/sites/reactflow.dev/src/pages/examples/edges/multi-connection-line.mdx
+++ b/sites/reactflow.dev/src/pages/examples/edges/multi-connection-line.mdx
@@ -1,0 +1,26 @@
+---
+title: Multi Connection Line
+---
+
+import ExampleViewer from '@/components/example-viewer';
+import ExampleLayout from '@/layouts/example-with-frontmatter';
+import { Callout } from 'nextra/components';
+
+<ExampleLayout>
+
+React Flow typically only allows one connection to be created at a time. This
+example builds on the [custom connection line](/examples/edges/custom-connectionline)
+example to show how to draw multiple connection lines from any selected nodes at
+once.
+
+<Callout type="info">
+  Pay attention to the `onConnect` handler. If you forget to include this then
+  only one connection will be created even if you have multiple selected nodes!
+</Callout>
+
+<ExampleViewer
+  codePath="example-flows/MultiConnectionLine"
+  additionalFiles={['ConnectionLine.js']}
+/>
+
+</ExampleLayout>

--- a/sites/reactflow.dev/src/pages/examples/edges/multi-connection-line.mdx
+++ b/sites/reactflow.dev/src/pages/examples/edges/multi-connection-line.mdx
@@ -1,5 +1,9 @@
 ---
 title: Multi Connection Line
+description:
+  React Flow typically only allows one connection to be created at a time. This
+  example builds on the custom connection line example to show how to draw multiple
+  connection lines from any selected nodes at once.
 ---
 
 import ExampleViewer from '@/components/example-viewer';

--- a/sites/reactflow.dev/src/pages/examples/edges/multi-connection-line.mdx
+++ b/sites/reactflow.dev/src/pages/examples/edges/multi-connection-line.mdx
@@ -27,4 +27,11 @@ once.
   additionalFiles={['ConnectionLine.js']}
 />
 
+<Callout type="warning">
+  This example makes use of the special `internalsSymbol` to access properties
+  on a node you won't typically need access to. Properties hidden behind this
+  symbol don't have the same stability guarantees as the public API, so use them
+  with caution.
+</Callout>
+
 </ExampleLayout>

--- a/sites/reactflow.dev/src/pages/whats-new/2024-02-09.mdx
+++ b/sites/reactflow.dev/src/pages/whats-new/2024-02-09.mdx
@@ -1,0 +1,26 @@
+---
+title: New example published!
+description:
+  Quite a while back, a user opened a GitHub issue asking us to add the ability
+  to draw multiple connection lines to the library. We don't have any plans to
+  add this to the library itself, but we hope this example helps folks who need
+  this functionality in their own apps.
+authors: [hayleigh]
+date: '2024-02-09'
+---
+
+import ExampleViewer from '@/components/example-viewer';
+
+# New example published!
+
+Quite a while back, a user opened a [GitHub issue](https://github.com/xyflow/web/issues/315)
+asking us to add the ability to draw multiple connection lines to the library. We
+don't have any plans to add this to the library itself, but we hope this example
+helps folks who need this functionality in their own apps. Check it out
+[here](/examples/edges/multi-connection-line).
+
+<ExampleViewer
+  codePath="example-flows/MultiConnectionLine"
+  additionalFiles={['ConnectionLine.js']}
+  showEditor={false}
+/>

--- a/sites/reactflow.dev/src/utils/routes.ts
+++ b/sites/reactflow.dev/src/utils/routes.ts
@@ -89,6 +89,7 @@ export type InternalRoute =
   | '/examples/edges/edge-types'
   | '/examples/edges/floating-edges'
   | '/examples/edges/markers'
+  | '/examples/edges/multi-connection-line'
   | '/examples/edges/simple-floating-edges'
   | '/examples/edges/updatable-edge'
   | '/examples/interaction/collaborative'
@@ -178,4 +179,5 @@ export type InternalRoute =
   | '/whats-new/2023-11-14'
   | '/whats-new/2023-12-06'
   | '/whats-new/2023-12-12'
-  | '/whats-new/2024-01-18';
+  | '/whats-new/2024-01-18'
+  | '/whats-new/2024-02-09';


### PR DESCRIPTION
Closes #315. We finally got round to cooking up an example! As always @bcakmakoglu contributed a non-trivial amount of the work ^.^


https://github.com/xyflow/web/assets/9001354/78a3d514-b980-4bce-9d39-18b40edfdd19

Not sure how I feel about importing and using `internalsSymbol` though... 