### PR TITLE
docs: Update documentation under the subheading "Adding a new node type"

### DIFF
--- a/sites/svelteflow.dev/src/pages/learn/guides/custom-nodes.mdx
+++ b/sites/svelteflow.dev/src/pages/learn/guides/custom-nodes.mdx
@@ -47,7 +47,7 @@ As you can see we've added the class name "nodrag" to the input. This prevents d
 
 ## Adding a new node type
 
-You can add a new node type to Svelte Flow by adding it to the [`nodeTypes` prop](/api-reference/svelte-flow#nodetypes). The `nodeTypes` prop is an object where the key is the name of the node type and the value is the component that should be rendered for this node type. Let's add the `TextUpdaterNode` to the `nodeTypes` prop:
+You can add a new node type to Svelte Flow by adding it to the [`nodeTypes` prop](/api-reference/svelte-flow#nodetypes). The `nodeTypes` prop is an object where the key is the name of the node type and the value is the component that should be rendered for this node type. Let's add the `ColorPickerNode` to the `nodeTypes` prop:
 
 ```svelte filename="App.svelte"
 <script>


### PR DESCRIPTION
Fix incorrect reference of `TextUpdaterNode` to `ColorPickerNode`