### PR TITLE
Fix "TypeScript" word typo in docs

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/advanced-use/typescript.mdx
+++ b/sites/reactflow.dev/src/pages/learn/advanced-use/typescript.mdx
@@ -5,7 +5,7 @@ description: React Flow is written in TypeScript, so you don't need to install t
 
 # Usage with TypeScript
 
-React Flow is written in TypesSript, so you don't need to install the types separately. In this section we setup a basic flow with the corresponding types.
+React Flow is written in TypeScript, so you don't need to install the types separately. In this section we setup a basic flow with the corresponding types.
 
 ## Usage
 


### PR DESCRIPTION
The page `sites/reactflow.dev/src/pages/learn/advanced-use/typescript.mdx` had a typo in the Usage with TypeScript section, the word TypeScript has been misspelled as `TypesSript`, this pull requests updates it to `TypeScript`.