### PR TITLE
Add missing imports to typescript.mdx

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/advanced-use/typescript.mdx
+++ b/sites/reactflow.dev/src/pages/learn/advanced-use/typescript.mdx
@@ -20,7 +20,9 @@ import ReactFlow, {
   Edge,
   OnNodesChange,
   OnEdgesChange,
-  OnConnect
+  OnConnect,
+  DefaultEdgeOptions,
+  NodeTypes
 } from 'reactflow';
 
 import CustomNode from './CustomNode';


### PR DESCRIPTION
When using the code shown on this page to kickstart a project, I noticed there were a couple of errors due to 'DefaultEdgeOptions' and 'NodeTypes' not having been imported.

Those imports are used in the following lines:

```
const defaultEdgeOptions: DefaultEdgeOptions = {
  animated: true,
};
 
const nodeTypes: NodeTypes = {
  custom: CustomNode,
};
```


This PR adds them so that issue no longer happen. 