### PR TITLE
Fixed typos in node-resize-control page

### DIFF
--- a/sites/reactflow.dev/src/pages/api-reference/components/node-resize-control.mdx
+++ b/sites/reactflow.dev/src/pages/api-reference/components/node-resize-control.mdx
@@ -18,6 +18,6 @@ To create your own resizing UI, you can use the `NodeResizeControl` component wh
 ## Props
 
 For TypeScript users, the props type for the `<NodeResizeControl />` component is exported
-as `NodeResizeControlrops`.
+as `ResizeControlProps`.
 
 <PropsTable {...nodeResizeControlProps} />

--- a/sites/svelteflow.dev/src/pages/api-reference/components/node-resize-control.mdx
+++ b/sites/svelteflow.dev/src/pages/api-reference/components/node-resize-control.mdx
@@ -19,6 +19,6 @@ To create your own resizing UI, you can use the `NodeResizeControl` component wh
 ## Props
 
 For TypeScript users, the props type for the `<NodeResizeControl />` component is exported
-as `NodeResizeControlrops`.
+as `ResizeControlProps`.
 
 <PropsTable {...nodeResizeControlProps} />


### PR DESCRIPTION
It seem there are typos in `Reference > Component > NodeResizeControl` and it is marked on image below 
<img width="1366" alt="Screenshot 2024-04-11 at 12 09 33 PM" src="https://github.com/xyflow/web/assets/32519740/dc339d2b-f1cf-43b8-b42f-b81b4b106cfd">
After checking xyflow repository NodeResizeControl component Type seems to be ResizeControlProps then I applied fix to both react and svelte