### PR TITLE
Use createWithEqualityFn in mind-map-app-with-react-flow.mdx

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/tutorials/mind-map-app-with-react-flow.mdx
+++ b/sites/reactflow.dev/src/pages/learn/tutorials/mind-map-app-with-react-flow.mdx
@@ -152,7 +152,7 @@ import {
   applyNodeChanges,
   applyEdgeChanges,
 } from 'reactflow';
-import { create } from 'zustand';
+import { createWithEqualityFn } from "zustand/traditional";
 
 export type RFState = {
   nodes: Node[];
@@ -161,7 +161,7 @@ export type RFState = {
   onEdgesChange: OnEdgesChange;
 };
 
-const useStore = create<RFState>((set, get) => ({
+const useStore = createWithEqualityFn<RFState>((set, get) => ({
   nodes: [
     {
       id: 'root',


### PR DESCRIPTION
# Reason for PR

**TL;DR**: Zustand warning `@deprecated — Use createWithEqualityFn from 'zustand/traditional'`

## Details
When following [ this example in the tutorial,](https://reactflow.dev/learn/tutorials/mind-map-app-with-react-flow#srcappindextsx-1) VSCode complains that this declaration using `create` is deprecated. 
Although the code works just fine, it recommends that we use `createWithEqualityFn` instead of `create`. It does solve the warning.

However, after some research, it seems that [Zustand might deprecate this `createWithEqualityFn`...](https://github.com/pmndrs/zustand/discussions/2243)

It seems that they initially had quite some confusions among the users, which lead to [v4.5.1 release fix](https://github.com/pmndrs/zustand/releases), but still using the zustand@latest did not fix this warning for our case.

Very trivial issue, but wanted to bring up to see what React Flow team thinks about it.

Thank you for this awesome library.

My Versions:
"reactflow": "^11.11.1",
"zustand": "^4.5.2"

## Screenshot 
![CleanShot 2024-04-18 at 10 18 45](https://github.com/xyflow/xyflow/assets/26427048/d341a9b6-276b-4156-8109-f7a47c91a1a0)

## Warning from VSCode

```ts
The signature '(selector: (state: RFState) => { nodes: Node[]; edges: Edge[]; onNodesChange: OnNodesChange; onEdgesChange: OnEdgesChange; }, equalityFn: (a: { ...; }, b: { ...; }) => boolean): { ...; }' of 'useRFStore' is deprecated.ts(6387)
react.d.mts(20, 8): The declaration was marked as deprecated here.
(alias) useRFStore<{
    nodes: Node[];
    edges: Edge[];
    onNodesChange: OnNodesChange;
    onEdgesChange: OnEdgesChange;
}>(selector: (state: RFState) => {
    nodes: Node[];
    edges: Edge[];
    onNodesChange: OnNodesChange;
    onEdgesChange: OnEdgesChange;
}, equalityFn: (a: {
    nodes: Node[];
    edges: Edge[];
    onNodesChange: OnNodesChange;
    onEdgesChange: OnEdgesChange;
}, b: {
    nodes: Node[];
    edges: Edge[];
    onNodesChange: OnNodesChange;
    onEdgesChange: OnEdgesChange;
}) => boolean): {
    nodes: Node[];
    edges: Edge[];
    onNodesChange: OnNodesChange;
    onEdgesChange: OnEdgesChange;
} (+2 overloads)
import useRFStore
@deprecated — Use createWithEqualityFn from 'zustand/traditional'
```



