### PR TITLE
refactor: on `getOutgoers()` hook, change misleading variable and fix typos

### DIFF
--- a/sites/reactflow.dev/src/pages/api-reference/utils/get-outgoers.mdx
+++ b/sites/reactflow.dev/src/pages/api-reference/utils/get-outgoers.mdx
@@ -2,7 +2,7 @@
 title: getOutgoers()
 description:
   'This util is used to tell you what nodes, if any, are connected to the given node
-  as a the target of an edge.'
+  as the target of an edge.'
 ---
 
 import { PropsTable } from '@/components/props-table';
@@ -13,7 +13,7 @@ import { signature } from '@/page-data/reference/utils/getOutgoers.ts';
 [Source on GitHub](https://github.com/xyflow/xyflow/blob/v11/packages/core/src/utils/graph.ts/#L25)
 
 This util is used to tell you what nodes, if any, are connected to the given node
-as a the _target_ of an edge.
+as the _target_ of an edge.
 
 ```ts
 import { getOutgoers } from 'reactflow';
@@ -21,7 +21,7 @@ import { getOutgoers } from 'reactflow';
 const nodes = [];
 const edges = [];
 
-const incomers = getOutgoers(
+const outgoers = getOutgoers(
   { id: '1', position: { x: 0, y: 0 }, data: { label: 'node' } },
   nodes,
   edges,


### PR DESCRIPTION
Fix typo and misleading variable name