### PR TITLE
Examples: Add entitree-flex layout example

### DIFF
--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/EntitreeFlexTree/CustomNode.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/EntitreeFlexTree/CustomNode.js
@@ -1,0 +1,77 @@
+import React, { memo } from 'react';
+import { Handle, Position } from 'reactflow';
+import { nodeHeight, nodeWidth } from './App';
+
+const { Top, Bottom, Left, Right } = Position;
+
+export default memo(({ data: nodeInfo, id: nodeId }) => {
+  const { isSpouse, isSibling, label, direction } = nodeInfo;
+
+  const isTreeHorizontal = direction === 'LR';
+
+  // Define the node style
+  const nodeStyle = {
+    height: nodeHeight,
+    minWidth: nodeWidth,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    border: '1px solid black',
+    borderRadius: '4px',
+  };
+
+  const getTargetPosition = () => {
+    if (isSpouse) {
+      return isTreeHorizontal ? Top : Left;
+    } else if (isSibling) {
+      return isTreeHorizontal ? Bottom : Right;
+    }
+    return isTreeHorizontal ? Left : Top;
+  };
+
+  const isRootNode = nodeInfo?.isRoot;
+  const hasChildren = !!nodeInfo?.children?.length;
+  const hasSiblings = !!nodeInfo?.siblings?.length;
+  const hasSpouses = !!nodeInfo?.spouses?.length;
+
+  return (
+    <div className="nodrag">
+      {/* For children */}
+      {hasChildren && (
+        <Handle
+          type="source"
+          position={isTreeHorizontal ? Right : Bottom}
+          id={isTreeHorizontal ? Right : Bottom}
+        />
+      )}
+
+      {/* For spouses */}
+      {hasSpouses && (
+        <Handle
+          type="source"
+          position={isTreeHorizontal ? Bottom : Right}
+          id={isTreeHorizontal ? Bottom : Right}
+        />
+      )}
+
+      {/* For siblings */}
+      {hasSiblings && (
+        <Handle
+          type="source"
+          position={isTreeHorizontal ? Top : Left}
+          id={isTreeHorizontal ? Top : Left}
+        />
+      )}
+
+      {/* Target Handle */}
+      {!isRootNode && (
+        <Handle
+          type={'target'}
+          position={getTargetPosition()}
+          id={getTargetPosition()}
+        />
+      )}
+      <div style={nodeStyle}>{label}</div>
+    </div>
+  );
+});

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/EntitreeFlexTree/index.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/EntitreeFlexTree/index.js
@@ -1,0 +1,188 @@
+import React, { useCallback } from 'react';
+import ReactFlow, {
+  addEdge,
+  ConnectionLineType,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  Position,
+} from 'reactflow';
+import { layoutFromMap } from 'entitree-flex';
+import CustomNode from './CustomNode';
+
+import 'reactflow/dist/style.css';
+import { initialTree, treeRootId } from './nodes-edges';
+
+export const nodeWidth = 150;
+export const nodeHeight = 36;
+
+const nodeTypes = {
+  custom: CustomNode,
+};
+
+const Orientation = {
+  Vertical: 'vertical',
+  Horizontal: 'horizontal',
+};
+
+const entitreeSettings = {
+  clone: true, // returns a copy of the input, if your application does not allow editing the original object
+  enableFlex: true, // has slightly better perfomance if turned off (node.width, node.height will not be read)
+  firstDegreeSpacing: 100, // spacing in px between nodes belonging to the same source, eg children with same parent
+  nextAfterAccessor: 'spouses', // the side node prop used to go sideways, AFTER the current node
+  nextAfterSpacing: 100, // the spacing of the "side" nodes AFTER the current node
+  nextBeforeAccessor: 'siblings', // the side node prop used to go sideways, BEFORE the current node
+  nextBeforeSpacing: 100, // the spacing of the "side" nodes BEFORE the current node
+  nodeHeight, // default node height in px
+  nodeWidth, // default node width in px
+  orientation: Orientation.Vertical, // "vertical" to see parents top and children bottom, "horizontal" to see parents left and
+  rootX: 0, // set root position if other than 0
+  rootY: 0, // set root position if other than 0
+  secondDegreeSpacing: 100, // spacing in px between nodes not belonging to same parent eg "cousin" nodes
+  sourcesAccessor: 'parents', // the prop used as the array of ancestors ids
+  sourceTargetSpacing: 100, // the "vertical" spacing between nodes in vertical orientation, horizontal otherwise
+  targetsAccessor: 'children', // the prop used as the array of children ids
+};
+
+const { Top, Bottom, Left, Right } = Position;
+
+const getLayoutedElements = (tree, rootId, direction = 'TB') => {
+  console.log({ tree, rootId });
+  const isTreeHorizontal = direction === 'LR';
+
+  const { nodes: entitreeNodes, rels: entitreeEdges } = layoutFromMap(
+    rootId,
+    tree,
+    {
+      ...entitreeSettings,
+      orientation: isTreeHorizontal
+        ? Orientation.Horizontal
+        : Orientation.Vertical,
+    },
+  );
+
+  const nodes = [],
+    edges = [];
+
+  entitreeEdges.forEach((edge) => {
+    const sourceNode = edge.source.id;
+    const targetNode = edge.target.id;
+
+    const newEdge = {};
+
+    newEdge.id = 'e' + sourceNode + targetNode;
+    newEdge.source = sourceNode;
+    newEdge.target = targetNode;
+    newEdge.type = 'smoothstep';
+    newEdge.animated = 'true';
+
+    // Check if target node is spouse or sibling
+    const isTargetSpouse = !!edge.target.isSpouse;
+    const isTargetSibling = !!edge.target.isSibling;
+
+    if (isTargetSpouse) {
+      newEdge.sourceHandle = isTreeHorizontal ? Bottom : Right;
+      newEdge.targetHandle = isTreeHorizontal ? Top : Left;
+    } else if (isTargetSibling) {
+      newEdge.sourceHandle = isTreeHorizontal ? Top : Left;
+      newEdge.targetHandle = isTreeHorizontal ? Bottom : Right;
+    } else {
+      newEdge.sourceHandle = isTreeHorizontal ? Right : Bottom;
+      newEdge.targetHandle = isTreeHorizontal ? Left : Top;
+    }
+
+    edges.push(newEdge);
+  });
+
+  entitreeNodes.forEach((node) => {
+    const newNode = {};
+
+    const isSpouse = !!node?.isSpouse;
+    const isSibling = !!node?.isSibling;
+    const isRoot = node?.id === rootId;
+
+    if (isSpouse) {
+      newNode.sourcePosition = isTreeHorizontal ? Bottom : Right;
+      newNode.targetPosition = isTreeHorizontal ? Top : Left;
+    } else if (isSibling) {
+      newNode.sourcePosition = isTreeHorizontal ? Top : Left;
+      newNode.targetPosition = isTreeHorizontal ? Bottom : Right;
+    } else {
+      newNode.sourcePosition = isTreeHorizontal ? Right : Bottom;
+      newNode.targetPosition = isTreeHorizontal ? Left : Top;
+    }
+
+    newNode.data = { label: node.name, direction, isRoot, ...node };
+    newNode.id = node.id;
+    newNode.type = 'custom';
+
+    newNode.width = nodeWidth;
+    newNode.height = nodeHeight;
+
+    newNode.position = {
+      x: node.x,
+      y: node.y,
+    };
+
+    nodes.push(newNode);
+  });
+
+  return { nodes, edges };
+};
+
+const updateLayout = () => {
+  const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
+    initialTree,
+    treeRootId,
+    'TB',
+  );
+  return [layoutedNodes, layoutedEdges];
+};
+
+const [layoutedNodes, layoutedEdges] = updateLayout();
+
+const LayoutFlow = () => {
+  const [nodes, setNodes, onNodesChange] = useNodesState(layoutedNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(layoutedEdges);
+
+  const onConnect = useCallback(
+    (params) =>
+      setEdges((eds) =>
+        addEdge(
+          { ...params, type: ConnectionLineType.SmoothStep, animated: true },
+          eds,
+        ),
+      ),
+    [],
+  );
+  const onLayout = useCallback(
+    (direction) => {
+      const { nodes: layoutedNodes, edges: layoutedEdges } =
+        getLayoutedElements(initialTree, treeRootId, direction);
+
+      setNodes([...layoutedNodes]);
+      setEdges([...layoutedEdges]);
+    },
+    [nodes, edges],
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onConnect={onConnect}
+      connectionLineType={ConnectionLineType.SmoothStep}
+      fitView
+      nodeTypes={nodeTypes}
+    >
+      <Panel position="top-right">
+        <button onClick={() => onLayout('TB')}>vertical layout</button>
+        <button onClick={() => onLayout('LR')}>horizontal layout</button>
+      </Panel>
+    </ReactFlow>
+  );
+};
+
+export default LayoutFlow;

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/EntitreeFlexTree/nodes-edges.js
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/EntitreeFlexTree/nodes-edges.js
@@ -1,0 +1,37 @@
+export const treeRootId = 1;
+export const initialTree = {
+  1: {
+    id: '1',
+    name: 'root',
+    type: 'input',
+    children: ['2', '3'],
+    siblings: ['8'],
+    spouses: ['10'],
+  },
+  2: { id: '2', name: 'child2' },
+  3: {
+    id: '3',
+    name: 'child3',
+    children: ['4', '5'],
+    siblings: ['9'],
+    spouses: ['6'],
+  },
+  4: { id: '4', name: 'grandChild4' },
+  5: { id: '5', name: 'grandChild5' },
+  6: { id: '6', name: 'spouse of child 3', isSpouse: true },
+  8: {
+    id: '8',
+    name: 'root sibling',
+    isSibling: true,
+  },
+  9: {
+    id: '9',
+    name: 'child3 sibling',
+    isSibling: true,
+  },
+  10: {
+    id: '10',
+    name: 'root spouse',
+    isSpouse: true,
+  },
+};

--- a/sites/reactflow.dev/src/pages/examples/layout/_meta.json
+++ b/sites/reactflow.dev/src/pages/examples/layout/_meta.json
@@ -2,6 +2,7 @@
   "sub-flows": "Sub Flow",
   "horizontal": "Horizontal Flow",
   "dagre": "Dagre Tree",
+  "entitree-flex": "Entitree Flex Tree",
   "elkjs": "Elkjs Tree",
   "elkjs-multiple-handles": "Elkjs Multiple Handles",
   "auto-layout": "Auto Layout",

--- a/sites/reactflow.dev/src/pages/examples/layout/entitree-flex.mdx
+++ b/sites/reactflow.dev/src/pages/examples/layout/entitree-flex.mdx
@@ -1,0 +1,18 @@
+---
+title: Entitree Flex Tree
+description: You can integrate entitree-flex with React Flow to create tree layouts that have sibling nodes and support nodes with different dimensions. This is really helpful if you want to create a family tree type layout.
+---
+
+import ExampleViewer from '@/components/example-viewer';
+import ExampleLayout from '@/layouts/example-with-frontmatter';
+
+<ExampleLayout>
+This example shows how you can integrate [entitree-flex](https://github.com/codeledge/entitree-flex) with React Flow to create tree layouts that can have sibling nodes and support nodes with different dimensions. 
+
+<ExampleViewer
+  codePath="example-flows/EntitreeFlexTree"
+  additionalFiles={['nodes-edges.js','CustomNode.js']}
+  dependencies={{ 'entitree-flex': 'latest' }}
+/>
+</ExampleLayout>
+


### PR DESCRIPTION
#### Description
This example shows how you can integrate [entitree-flex](https://github.com/codeledge/entitree-flex) with React Flow to create tree layouts that can have sibling nodes. Entitree flex also supports nodes with different dimensions.

#### Screencast 
https://d.pr/v/hZjhn4