### PR TITLE
fix: 🛠️ Correct useCallback usage in useOnSelectionChange example

### DIFF
--- a/sites/reactflow.dev/src/pages/api-reference/hooks/use-on-selection-change.mdx
+++ b/sites/reactflow.dev/src/pages/api-reference/hooks/use-on-selection-change.mdx
@@ -24,7 +24,7 @@ _either_ nodes or edges changes.
 </Callout>
 
 ```jsx
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import ReactFlow, { useOnSelectionChange } from 'reactflow';
 
 function SelectionDisplay() {
@@ -32,7 +32,7 @@ function SelectionDisplay() {
   const [selectedEdges, setSelectedEdges] = useState([]);
 
   // the passed handler has to be memoized, otherwise the hook will not work correctly
-  const onChange = useCallback({ nodes, edges }) => {
+  const onChange = useCallback(({ nodes, edges }) => {
     setSelectedNodes(nodes.map((node) => node.id));
     setSelectedEdges(edges.map((edge) => edge.id));
   }, [])


### PR DESCRIPTION
The example provided for the useOnSelectionChange hook contained errors in the use of the useCallback hook. This commit addresses the following issues:

1. Added missing import statement for useCallback from 'react'.
2. Corrected the syntax of useCallback.