### PR TITLE
Fixed a broken link in api-reference documentation

### DIFF
--- a/sites/svelteflow.dev/src/pages/api-reference/types/edge-marker.mdx
+++ b/sites/svelteflow.dev/src/pages/api-reference/types/edge-marker.mdx
@@ -8,7 +8,7 @@ import { edgeMarkerFields } from '@/page-data/reference/types/EdgeMarker.ts';
 
 # EdgeMarker
 
-You can customize the built-in edge markers with the `edgeMarker` [Edge](/api-reference/types/Edge) prop.
+You can customize the built-in edge markers with the `edgeMarker` [Edge](/api-reference/types/edge) prop.
 
 ```ts
 export type EdgeMarker = {


### PR DESCRIPTION
This is just a small pull request to fix a broken link.

Seems to be a simple error with the capital letter:
This works: https://svelteflow.dev/api-reference/types/edge
This doesn't: https://svelteflow.dev/api-reference/types/Edge
