### PR TITLE
Link useUpdateNodeInternals in error 008

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/troubleshooting/index.mdx
+++ b/sites/reactflow.dev/src/pages/learn/troubleshooting/index.mdx
@@ -369,7 +369,7 @@ This can happen when you are trying to [reconnect an edge](/examples/edges/recon
 <div id="008" />
 ### Couldn't create edge for source/target handle id: "some-id"; edge id: "some-id".
 
-This can happen if you are working with multiple handles and a handle is not found by its `id` property. Please see the [Custom Node Example](/examples/nodes/custom-node) for an example of working with multiple handles.
+This can happen if you are working with multiple handles and a handle is not found by its `id` property or if you haven't [updated the node internals after adding or removing handles](/api-reference/hooks/use-update-node-internals). Please see the [Custom Node Example](/examples/nodes/custom-node) for an example of working with multiple handles.
 
 <div id="009" />
 ### Marker type doesn't exist.

--- a/sites/reactflow.dev/src/pages/learn/troubleshooting/index.mdx
+++ b/sites/reactflow.dev/src/pages/learn/troubleshooting/index.mdx
@@ -369,7 +369,7 @@ This can happen when you are trying to [reconnect an edge](/examples/edges/recon
 <div id="008" />
 ### Couldn't create edge for source/target handle id: "some-id"; edge id: "some-id".
 
-This can happen if you are working with multiple handles and a handle is not found by its `id` property or if you haven't [updated the node internals after adding or removing handles](/api-reference/hooks/use-update-node-internals). Please see the [Custom Node Example](/examples/nodes/custom-node) for an example of working with multiple handles.
+This can happen if you are working with multiple handles and a handle is not found by its `id` property or if you haven't [updated the node internals after adding or removing handles](/api-reference/hooks/use-update-node-internals) programmatically. Please see the [Custom Node Example](/examples/nodes/custom-node) for an example of working with multiple handles.
 
 <div id="009" />
 ### Marker type doesn't exist.


### PR DESCRIPTION
Links useUpdateNodeInternals so that users seeing error 008 because they modified handles programmatically can easily fix their bug.