### PR TITLE
Added missing documentation for `selectionOnDrag` property in svelteflow.dev

### DIFF
--- a/sites/svelteflow.dev/src/page-data/reference/SvelteFlow.ts
+++ b/sites/svelteflow.dev/src/page-data/reference/SvelteFlow.ts
@@ -306,6 +306,7 @@ export const interactionProps: PropsTableProps = {
       which mouse buttons can activate panning. For example, [0,2] would allow
       panning with the left and right mouse buttons.`,
     },
+    { name: 'selectionOnDrag', type: 'boolean', default: 'false' },
     {
       name: 'selectionMode',
       type: '"partial" | "full"',


### PR DESCRIPTION
`selectionOnDrag` is present on [reactflow.dev](https://reactflow.dev/api-reference/react-flow#selection-on-drag), but is missing on [svelteflow.dev](https://svelteflow.dev/api-reference/svelte-flow#selection-on-drag).

Despite being missing from that page, the feature seems to be implemented.

I took the same definition from the [react page data](https://github.com/xyflow/web/blob/44b1c3ca8528680690f60aacabdcfadb0189dcfe/sites/reactflow.dev/src/page-data/reference/ReactFlow.props.ts#L501).