### PR TITLE
chore(svelte-docs): fix typo

### DIFF
--- a/apps/svelte-examples/src/routes/examples/nodes/update-node/+page.svelte
+++ b/apps/svelte-examples/src/routes/examples/nodes/update-node/+page.svelte
@@ -100,7 +100,7 @@
     margin-top: 10px;
   }
 
-  :gloabl(.updatenode__checkboxwrapper) {
+  :global(.updatenode__checkboxwrapper) {
     margin-top: 10px;
     display: flex;
     align-items: center;


### PR DESCRIPTION
# Fixed Typo

Changed `:gloabl` to `:global`