### PR TITLE
fix(react-docs): update validation example class names

### DIFF
--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/Validation/index.css
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/Validation/index.css
@@ -22,10 +22,10 @@
 
 }
 
-.validationflow .react-flow__handle-connecting {
+.validationflow .react-flow__handle.connectingto {
   background: #ff6060;
 }
 
-.validationflow .react-flow__handle-valid {
+.validationflow .react-flow__handle.valid {
   background: #55dd99;
 }


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Update validation class names in the validation example
	- `.react-flow__handle-valid` -> `.react-flow__handle.valid`
	- `.react-flow__handle-connecting` -> `.react-flow__handle.connectingto`