### PR TITLE
chore(docs): update migration docs to use actual old api values for node position

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/troubleshooting/migrate-to-v12.mdx
+++ b/sites/reactflow.dev/src/pages/learn/troubleshooting/migrate-to-v12.mdx
@@ -223,12 +223,12 @@ const nodes = [
 
 {<h3>7. Custom node props</h3>}
 
-We renamed the `posX` and `posY` props to `positionAbsoluteX` and `positionAbsoluteY`
+We renamed the `xPos` and `yPos` props to `positionAbsoluteX` and `positionAbsoluteY`
 
 {<h4>Old API</h4>}
 
 ```js
-function CustomNode({ posX, posY }) {
+function CustomNode({ xPos, yPos }) {
   ...
 }
 ```


### PR DESCRIPTION
The old values in the api is not `posX` and `posY`, but rather `xPos` and `yPos`.