### PR TITLE
fix: data property is required in node objects

### DIFF
--- a/sites/reactflow.dev/src/components/example-viewer/api-flows/GettingStarted2/index.js
+++ b/sites/reactflow.dev/src/components/example-viewer/api-flows/GettingStarted2/index.js
@@ -5,6 +5,7 @@ const nodes = [
   {
     id: '1',
     position: { x: 0, y: 0 },
+    data: { label: 'Hello' },
   },
 ];
 

--- a/sites/reactflow.dev/src/pages/learn/getting-started/building-a-flow.mdx
+++ b/sites/reactflow.dev/src/pages/learn/getting-started/building-a-flow.mdx
@@ -40,6 +40,7 @@ const nodes = [
   {
     id: '1', // required
     position: { x: 0, y: 0 }, // required
+    data: { label: 'Hello' }, // required
   },
 ];
 ```


### PR DESCRIPTION
In the [Building a flow](https://reactflow.dev/learn/getting-started/building-a-flow#adding-nodes) page, the required `data` property is missing from the first example.

```diff
const nodes = [
  {
    id: '1', // required
    position: { x: 0, y: 0 }, // required
+   data: { label: 'Hello' }, // required
  },
];
```