### PR TITLE
refactor(reactflow,svelteflow): use context to persist dragged node type

### DIFF
--- a/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/+page.svelte
+++ b/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/+page.svelte
@@ -2,8 +2,11 @@
   import { SvelteFlowProvider } from '@xyflow/svelte';
 
   import Flow from './Flow.svelte';
+  import DnDProvider from './DnDProvider.svelte';
 </script>
 
 <SvelteFlowProvider>
-  <Flow />
+  <DnDProvider>
+    <Flow />
+  </DnDProvider>
 </SvelteFlowProvider>

--- a/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/DnDProvider.svelte
+++ b/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/DnDProvider.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { onDestroy, setContext } from 'svelte';
+  import { writable } from 'svelte/store';
+
+  const dndType = writable(null);
+
+  setContext('dnd', dndType);
+
+  onDestroy(() => {
+    dndType.set(null);
+  });
+</script>
+
+<slot />

--- a/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/Flow.svelte
+++ b/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/Flow.svelte
@@ -12,6 +12,7 @@
   import Sidebar from './Sidebar.svelte';
 
   import '@xyflow/svelte/dist/style.css';
+  import { useDnD } from './utils';
 
   const nodes = writable([
     {
@@ -50,6 +51,9 @@
   ]);
 
   const { screenToFlowPosition } = useSvelteFlow();
+
+  const type = useDnD();
+
   const onDragOver = (event: DragEvent) => {
     event.preventDefault();
 
@@ -61,11 +65,9 @@
   const onDrop = (event: DragEvent) => {
     event.preventDefault();
 
-    if (!event.dataTransfer) {
-      return null;
+    if (!$type) {
+      return;
     }
-
-    const type = event.dataTransfer.getData('application/svelteflow');
 
     const position = screenToFlowPosition({
       x: event.clientX,
@@ -74,7 +76,7 @@
 
     const newNode = {
       id: `${Math.random()}`,
-      type,
+      type: $type,
       position,
       data: { label: `${type} node` },
       origin: [0.5, 0.0]

--- a/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/Sidebar.svelte
+++ b/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/Sidebar.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+  import { useDnD } from './utils';
+
+  const type = useDnD();
+
   const onDragStart = (event: DragEvent, nodeType: string) => {
     if (!event.dataTransfer) {
       return null;
     }
 
-    event.dataTransfer.setData('application/svelteflow', nodeType);
+    type.set(nodeType);
+
     event.dataTransfer.effectAllowed = 'move';
   };
 </script>

--- a/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/utils.ts
+++ b/apps/svelte-examples/src/routes/examples/interaction/drag-and-drop/utils.ts
@@ -1,0 +1,6 @@
+import { getContext } from 'svelte';
+import type { Writable } from 'svelte/store';
+
+export const useDnD = () => {
+  return getContext('dnd') as Writable<string | null>;
+};

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/DragNDrop/DnDContext.jsx
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/DragNDrop/DnDContext.jsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from 'react';
+
+const DnDContext = createContext([null, (_) => {}]);
+
+export const DnDProvider = ({ children }) => {
+  const [type, setType] = useState(null);
+
+  return (
+    <DnDContext.Provider value={[type, setType]}>
+      {children}
+    </DnDContext.Provider>
+  );
+}
+
+export default DnDContext;
+
+export const useDnD = () => {
+  return useContext(DnDContext);
+}

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/DragNDrop/Sidebar.jsx
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/DragNDrop/Sidebar.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { useDnD } from './DnDContext';
 
 export default () => {
+  const [_, setType] = useDnD();
+
   const onDragStart = (event, nodeType) => {
-    event.dataTransfer.setData('application/reactflow', nodeType);
+    setType(nodeType);
     event.dataTransfer.effectAllowed = 'move';
   };
 

--- a/sites/reactflow.dev/src/components/example-viewer/example-flows/DragNDrop/index.jsx
+++ b/sites/reactflow.dev/src/components/example-viewer/example-flows/DragNDrop/index.jsx
@@ -11,6 +11,7 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import Sidebar from './Sidebar';
+import { DnDProvider, useDnD } from './DnDContext';
 
 import './index.css';
 
@@ -31,6 +32,7 @@ const DnDFlow = () => {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const { screenToFlowPosition } = useReactFlow();
+  const [type] = useDnD();
 
   const onConnect = useCallback(
     (params) => setEdges((eds) => addEdge(params, eds)),
@@ -46,10 +48,8 @@ const DnDFlow = () => {
     (event) => {
       event.preventDefault();
 
-      const type = event.dataTransfer.getData('application/reactflow');
-
       // check if the dropped element is valid
-      if (typeof type === 'undefined' || !type) {
+      if (!type) {
         return;
       }
 
@@ -69,7 +69,7 @@ const DnDFlow = () => {
 
       setNodes((nds) => nds.concat(newNode));
     },
-    [screenToFlowPosition],
+    [screenToFlowPosition, type],
   );
 
   return (
@@ -95,6 +95,8 @@ const DnDFlow = () => {
 
 export default () => (
   <ReactFlowProvider>
-    <DnDFlow />
+    <DnDProvider>
+      <DnDFlow />
+    </DnDProvider>
   </ReactFlowProvider>
 );

--- a/sites/reactflow.dev/src/pages/examples/interaction/drag-and-drop.mdx
+++ b/sites/reactflow.dev/src/pages/examples/interaction/drag-and-drop.mdx
@@ -13,6 +13,6 @@ A drag and drop user interface is very common for node-based workflow editors. T
 
 <ExampleViewer
   codePath="example-flows/DragNDrop"
-  additionalFiles={['Sidebar.jsx', 'index.css']}
+  additionalFiles={['Sidebar.jsx', 'DnDContext.jsx', 'index.css']}
 />
 </ExampleLayout>


### PR DESCRIPTION
# 🚀 What's changed?
<!--- Tell us what changes this pr contains -->

- Use React/Svelte context to persist the dragged node type
- Use context value on drop of node
- Replace `dataTransfer` usages

# 🌻 Resolves

- #465 