### PR TITLE
feat(reactflow,svelteflow): add documentation for `getHandleConnections`

### DIFF
--- a/sites/reactflow.dev/src/page-data/reference/types/ReactFlowInstance.fields.ts
+++ b/sites/reactflow.dev/src/page-data/reference/types/ReactFlowInstance.fields.ts
@@ -56,7 +56,7 @@ export const nodesAndEdgesFields: PropsTableProps = {
     },
     {
       name: 'updateNodeData',
-      type: `( id: string, dataUpdate: Partial<NodeType['data']> | ((edge: NodeType) => Partial<NodeType['data']>), options?: { replace: boolean }) => void`,
+      type: `(id: string, dataUpdate: Partial<NodeType['data']> | ((edge: NodeType) => Partial<NodeType['data']>), options?: { replace: boolean }) => void`,
     },
     {
       name: 'updateEdge',
@@ -64,8 +64,13 @@ export const nodesAndEdgesFields: PropsTableProps = {
     },
     {
       name: 'updateEdgeData',
-      type: `( id: string, dataUpdate: Partial<EdgeType['data']> | ((edge: EdgeType) => Partial<EdgeType['data']>), options?: { replace: boolean }) => void`,
+      type: `(id: string, dataUpdate: Partial<EdgeType['data']> | ((edge: EdgeType) => Partial<EdgeType['data']>), options?: { replace: boolean }) => void`,
     },
+    {
+      name: 'getHandleConnections',
+      type: `({ type, nodeId, id }: { type: HandleType, nodeId: string, id?: string | null }) => HandleConnection[]`,
+      description: `Get all the connections of a handle belonging to a specific node. The type parameter be either 'source' or 'target'.`,
+    }
   ],
 };
 

--- a/sites/svelteflow.dev/src/page-data/reference/hooks/useSvelteFlow.ts
+++ b/sites/svelteflow.dev/src/page-data/reference/hooks/useSvelteFlow.ts
@@ -136,5 +136,10 @@ export const signature: PropsTableProps = {
       description:
         'This function returns a JSON representation of your current Svelte Flow graph.',
     },
+    {
+      name: 'getHandleConnections',
+      type: `({ type, nodeId, id }: { type: HandleType, nodeId: string, id?: string | null }) => HandleConnection[]`,
+      description: `Get all the connections of a handle belonging to a specific node. The type parameter be either 'source' or 'target'.`,
+    },
   ],
 };


### PR DESCRIPTION
# 🚀 What's changed?

<!--- Tell us what changes this pr contains -->

- Add documentation for `getHandleConnections` to API-reference pages of `useReactFlow` & `useSvelteFlow`

Related to: https://github.com/xyflow/xyflow/pull/4574