### PR TITLE
fix(reactflow,svelteflow): add missing verb to description of `getHandleConnections`

### DIFF
--- a/sites/reactflow.dev/src/page-data/reference/types/ReactFlowInstance.fields.ts
+++ b/sites/reactflow.dev/src/page-data/reference/types/ReactFlowInstance.fields.ts
@@ -69,7 +69,7 @@ export const nodesAndEdgesFields: PropsTableProps = {
     {
       name: 'getHandleConnections',
       type: `({ type, nodeId, id }: { type: HandleType, nodeId: string, id?: string | null }) => HandleConnection[]`,
-      description: `Get all the connections of a handle belonging to a specific node. The type parameter be either 'source' or 'target'.`,
+      description: `Get all the connections of a handle belonging to a specific node. The type parameter can be either 'source' or 'target'.`,
     }
   ],
 };

--- a/sites/svelteflow.dev/src/page-data/reference/hooks/useSvelteFlow.ts
+++ b/sites/svelteflow.dev/src/page-data/reference/hooks/useSvelteFlow.ts
@@ -139,7 +139,7 @@ export const signature: PropsTableProps = {
     {
       name: 'getHandleConnections',
       type: `({ type, nodeId, id }: { type: HandleType, nodeId: string, id?: string | null }) => HandleConnection[]`,
-      description: `Get all the connections of a handle belonging to a specific node. The type parameter be either 'source' or 'target'.`,
+      description: `Get all the connections of a handle belonging to a specific node. The type parameter can be either 'source' or 'target'.`,
     },
   ],
 };


### PR DESCRIPTION
# 🚀 What's changed?

<!--- Tell us what changes this pr contains -->

- Add missing verb to the description of `getHandleConnections`
	- Was previously saying `The type parameter be either 'source' or 'target'. ` when it should be saying `The type parameter can be either 'source' or 'target'.` (missing verb `can`)