### PR TITLE
fix(reactflow,svelteflow): remove `positionAbsolute` from node field definitions

### DIFF
--- a/sites/svelteflow.dev/src/page-data/reference/types/Node.fields.ts
+++ b/sites/svelteflow.dev/src/page-data/reference/types/Node.fields.ts
@@ -23,7 +23,6 @@ export const nodeFields: PropsTableProps = {
     { name: 'zIndex?', type: 'number' },
     { name: 'extent?', type: '"parent" | CoordinateExtent' },
     { name: 'expandParent?', type: 'boolean' },
-    { name: 'positionAbsolute?', type: 'XYPosition' },
     { name: 'ariaLabel?', type: 'string' },
     { name: 'origin?', type: 'NodeOrigin' },
     { name: 'style?', type: 'string' },


### PR DESCRIPTION
# 🚀 What's changed?

<!--- Tell us what changes this pr contains -->

- Remove `positionAbsolute` from node field definitions as it's been removed from the user node type since v12