### PR TITLE
fix(custom-handle-example): update the custom handle example to svelte syntax

### DIFF
--- a/sites/svelteflow.dev/src/pages/api-reference/components/handle.mdx
+++ b/sites/svelteflow.dev/src/pages/api-reference/components/handle.mdx
@@ -44,17 +44,26 @@ connection source matches a given id.
 
 ```svelte
 <script>
-import { Handle, Position } from '@xyflow/svelte';
+	import { Handle, Position } from '@xyflow/svelte';
+
+	export let position;
+	export let source;
+
+	function isValidConnection(connection) {
+		if (connection.source === source) {
+			return true;
+		}
+		return false;
+	}
+
 </script>
 
-export const TargetHandleWithValidation = ({ position, source }) => (
-  <Handle
-    type="target"
-    position={position}
-    isValidConnection={(connection) => connection.source === source}
-    style={{ background: '#fff' }}
-  />
-);
+<Handle
+	type="target"
+	position={position}
+	{isValidConnection}
+	style="background: #fff"
+/>
 ```
 
 ### Style handles when connecting


### PR DESCRIPTION
Hey, I've been working with your package (which is awesome!) in svelte. I came to implementing a handle with a custom validator and found that the syntax seemed to follow react convention rather than svelte. I've tried to update it to svelte syntax.