### PR TITLE
chore(docs): update EdgeChange types documentation.

### DIFF
--- a/sites/reactflow.dev/src/page-data/reference/types/EdgeChange.fields.ts
+++ b/sites/reactflow.dev/src/page-data/reference/types/EdgeChange.fields.ts
@@ -4,6 +4,7 @@ export const edgeAddChangeFields: PropsTableProps = {
   props: [
     { name: 'type', type: '"add"' },
     { name: 'item', type: 'Edge<T>' },
+    { name: 'index', type: 'number | undefined' },
   ],
 };
 
@@ -14,9 +15,10 @@ export const edgeRemoveChangeFields: PropsTableProps = {
   ],
 };
 
-export const edgeResetChangeFields: PropsTableProps = {
+export const edgeReplaceChangeFields: PropsTableProps = {
   props: [
-    { name: 'type', type: '"reset"' },
+    { name: 'type', type: '"replace"' },
+    { name: 'id', type: 'string' },
     { name: 'item', type: 'Edge<T>' },
   ],
 };

--- a/sites/reactflow.dev/src/pages/api-reference/types/edge-change.mdx
+++ b/sites/reactflow.dev/src/pages/api-reference/types/edge-change.mdx
@@ -10,7 +10,7 @@ import { PropsTable } from '@/components/props-table';
 import {
   edgeAddChangeFields,
   edgeRemoveChangeFields,
-  edgeResetChangeFields,
+  edgeReplaceChangeFields,
   edgeSelectionChangeFields,
 } from '@/page-data/reference/types/EdgeChange.fields.ts';
 
@@ -41,9 +41,9 @@ export type EdgeChange =
 
 <PropsTable {...edgeRemoveChangeFields} />
 
-### EdgeResetChange
+### EdgeReplaceChange
 
-<PropsTable {...edgeResetChangeFields} />
+<PropsTable {...edgeReplaceChangeFields} />
 
 ### EdgeSelectionChange
 


### PR DESCRIPTION
based on [changes.ts](https://github.com/xyflow/xyflow/blob/eb71e34d44229689b7424995f370111b4d490c1c/packages/system/src/types/changes.ts#L56C1-L68C3)

```js
export type EdgeSelectionChange = NodeSelectionChange;
export type EdgeRemoveChange = NodeRemoveChange;
export type EdgeAddChange<EdgeType extends EdgeBase = EdgeBase> = {
    item: EdgeType;
    type: 'add';
    index?: number;
};
export type EdgeReplaceChange<EdgeType extends EdgeBase = EdgeBase> = {
    id: string;
    item: EdgeType;
    type: 'replace';
};
```