### PR TITLE
Fix a couple of typos in the layouting docs.

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/layouting/layouting.mdx
+++ b/sites/reactflow.dev/src/pages/learn/layouting/layouting.mdx
@@ -111,8 +111,8 @@ layouts, and enclosure diagrams.
 - Repo: https://github.com/d3/d3-force
 - Docs: https://d3js.org/d3-force
 
-Force something more interesting than a tree, a force-directed layout might be
-the way to go. D3-Force is a physics-based layouting library that can be used
+For something more interesting than a tree, a force-directed layout might be
+the way to go. D3-Force is a physics-based layouting library that can be used to
 position nodes by applying different forces to them.
 
 As a consequence, it's a little more complicated to configure and use compared to


### PR DESCRIPTION
Noticed a couple of typos in the docs about Layouting, so figured I would fix them for ya.