### PR TITLE
Fix a duplicated word in the state management docs.

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/advanced-use/state-management.mdx
+++ b/sites/reactflow.dev/src/pages/learn/advanced-use/state-management.mdx
@@ -19,7 +19,7 @@ export const getStaticProps = getStaticCode(['learn/state-management', 'learn/st
   with the concepts of state management libraries and how to use them.
 </Callout>
 
-In this guide we are explaining how you could use React Flow with the state management library [Zustand](https://github.com/pmndrs/zustand). We will build a little app where every node has a color chooser that updates its background color. In this guide we are are using Zustand, because we are already using it internally for React Flow, but of course you can use any other library like [Redux](https://redux.js.org/), [Recoil](https://recoiljs.org/) or [Jotai](https://jotai.org/) as well.
+In this guide we are explaining how you could use React Flow with the state management library [Zustand](https://github.com/pmndrs/zustand). We will build a little app where every node has a color chooser that updates its background color. In this guide we are using Zustand, because we are already using it internally for React Flow, but of course you can use any other library like [Redux](https://redux.js.org/), [Recoil](https://recoiljs.org/) or [Jotai](https://jotai.org/) as well.
 
 As you might have seen in the previous guides and examples, React Flow can easily be used with a local component state for handling the nodes and edges of your diagram. When your app grows and you want to alter your state from within your nodes for example, things can get more complex. To avoid passing down functions through the node data field, you could use a [React context](https://reactjs.org/docs/context.html) or add a state management library as explained in this guide.
 


### PR DESCRIPTION
The word are was duplicated twice in the document and has been removed.