### PR TITLE
Fix a wrong link in the devtools-and-debugging docs.

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/advanced-use/devtools-and-debugging.mdx
+++ b/sites/reactflow.dev/src/pages/learn/advanced-use/devtools-and-debugging.mdx
@@ -46,7 +46,7 @@ own projects and modify them to suit your needs: each component works independen
 
 ## Node Inspector
 
-The `<NodeInspector />` component makes use of our [`useNodes`](/api-reference/hooks/use-names)
+The `<NodeInspector />` component makes use of our [`useNodes`](/api-reference/hooks/use-nodes)
 hook to access all the nodes in the flow. Typically we discourage using this hook
 because it will trigger a re-render any time _any_ of your nodes change, but that's
 exactly what makes it so useful for debugging!


### PR DESCRIPTION
The link to 'use-nodes' in the document was incorrect and has now been corrected.

Thank you for checking.