### PR TITLE
Fix several typos in the docs.

### DIFF
--- a/sites/reactflow.dev/src/pages/api-reference/hooks/use-edges.mdx
+++ b/sites/reactflow.dev/src/pages/api-reference/hooks/use-edges.mdx
@@ -40,7 +40,7 @@ const nodes = useEdges<CustomEdgeType>();
 
 ## Notes
 
-- Relying on `useEdges` unecessarily can be a common cause of performance
+- Relying on `useEdges` unnecessarily can be a common cause of performance
   issues. Whenever any edge changes, this hook will cause the component to
   re-render. Often we actually care about something more specific, like when
   the _number_ of edges changes: where possible try to use

--- a/sites/reactflow.dev/src/pages/api-reference/hooks/use-nodes.mdx
+++ b/sites/reactflow.dev/src/pages/api-reference/hooks/use-nodes.mdx
@@ -42,7 +42,7 @@ const nodes = useNodes<CustomNodeType>();
 
 ## Notes
 
-- Relying on `useNodes` unecessarily can be a common cause of performance
+- Relying on `useNodes` unnecessarily can be a common cause of performance
   issues. Whenever any node changes, this hook will cause the component to
   re-render. Often we actually care about something more specific, like when
   the _number_ of nodes changes: where possible try to use

--- a/sites/reactflow.dev/src/references/hooks/useStore.ts
+++ b/sites/reactflow.dev/src/references/hooks/useStore.ts
@@ -14,8 +14,8 @@ export const signature: PropsTableProps = {
       name: 'equalityFn?',
       type: '(prev: T, next: T) => boolean',
       description: `A function to compare the previous and next value. This is
-      incredibly useful for preventing uneccessary re-renders. Good sensible
-      defaults are using Object.is or importing zustand/shaddlow, but you can
+      incredibly useful for preventing unnecessary re-renders. Good sensible
+      defaults are using Object.is or importing zustand/shallow, but you can
       be as granular as you like.`,
     },
     { name: 'Returns' },


### PR DESCRIPTION
I've fixed several typos in the documentation. Thank you.

- uneccessarily, unecessarily -> unnecessarily
- unecessary -> unnecessary
- zustand/shaddlow -> zustand/shallow