### PR TITLE
fix(pricing-table): css override for scroll locked select component

### DIFF
--- a/sites/reactflow.dev/src/global.css
+++ b/sites/reactflow.dev/src/global.css
@@ -17,6 +17,11 @@
   }
 }
 
+html body[data-scroll-locked] {
+  overflow: visible !important;
+  margin-right: 0 !important;
+}
+
 /* .nextra-nav-container nav .nextra-scrollbar > a[href='/components']:after {
   content: 'beta';
   position: absolute;


### PR DESCRIPTION
Closes #354 

Fix pulled from this issue: 
https://github.com/shadcn-ui/ui/issues/4227

It seems  like this is a common problem. Wanted to have it reviewed in case I'm not considering potential blowback from this css. 