### PR TITLE
deref svelte store by adding $ prefix

### DIFF
--- a/apps/example-apps/svelte/examples/interaction/drag-and-drop/Flow.svelte
+++ b/apps/example-apps/svelte/examples/interaction/drag-and-drop/Flow.svelte
@@ -78,7 +78,7 @@
       id: `${Math.random()}`,
       type: $type,
       position,
-      data: { label: `${type} node` },
+      data: { label: `${$type} node` },
       origin: [0.5, 0.0]
     } satisfies Node;
 


### PR DESCRIPTION
hello, going through the examples at the moment and noticed a small error in the drag and drop example:
https://svelteflow.dev/examples/interaction/drag-and-drop

if you drag and drop a node it will be called [object Object] node, because the label you assign is a store. I just added the $ prefix to deref the store:
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/11465e58-3a57-465a-9722-509da14872b8">
