### PR TITLE
Fixed Thlelte-flow example.

### DIFF
--- a/apps/example-apps/svelte/examples/misc/threlte-flow/ThrelteScene.svelte
+++ b/apps/example-apps/svelte/examples/misc/threlte-flow/ThrelteScene.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { T, useThrelte, useFrame } from '@threlte/core';
+  import { T, useThrelte, useTask } from '@threlte/core';
   import type { FlowState } from './nodes-and-edges';
   import type { Writable } from 'svelte/store';
 
@@ -28,9 +28,9 @@
 
   $: $camera.position.set(0, 0, +$flowState.zoom);
 
-  let t: number;
-  useFrame(({ clock }) => {
-    t = clock.getElapsedTime();
+  let t: number = 0;
+  useTask((delta: number) => {
+    t += delta;
   });
 </script>
 


### PR DESCRIPTION
useFrame, which was deprecated and no longer works, was changed to useTask.

svelte/examples/misc/threlte-flow