### PR TITLE
Fix duplicate 'export default' in slide-shows tutorial

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/tutorials/slide-shows-with-react-flow.mdx
+++ b/sites/reactflow.dev/src/pages/learn/tutorials/slide-shows-with-react-flow.mdx
@@ -273,7 +273,7 @@ const nodeTypes = {
   slide: Slide,
 };
 
-export default export default function App() {
+export default function App() {
   const nodes = [
     {
       id: '0',
@@ -487,7 +487,7 @@ const nodeTypes = {
 const initialSlide = '0';
 const { nodes, edges } = slidesToElements(initialSlide, slides);
 
-export default export default function App() {
+export default function App() {
   return (
     <ReactFlow
       nodes={nodes}


### PR DESCRIPTION
This PR fixes a syntax error in the slide-shows-with-react-flow.mdx file. 
The file contained two 'export default' statements, which is invalid JavaScript syntax.

Changes made:
- Removed the redundant 'export default' statement.

This fix ensures that the tutorial code compiles correctly and prevents confusion for readers.
