### PR TITLE
Fixed edge-label-renderer example syntax (svelte)

### DIFF
--- a/sites/svelteflow.dev/src/pages/api-reference/components/edge-label-renderer.mdx
+++ b/sites/svelteflow.dev/src/pages/api-reference/components/edge-label-renderer.mdx
@@ -26,7 +26,10 @@ the EdgeLabelRenderer internally to render edge labels.
 <script lang="ts">
   import { getBezierPath, EdgeLabelRenderer, BaseEdge } from '@xyflow/svelte';
 
-  $: [edgePath, labelX, labelY] = getBezierPath(props);
+  export let id: $$Props['id'];
+  export let data: $$Props['data'];
+
+  $: [edgePath, labelX, labelY] = getBezierPath($$props);
 </script>
 
 <BaseEdge id={id} path={edgePath} />
@@ -41,7 +44,7 @@ the EdgeLabelRenderer internally to render edge labels.
       fontSize: 12,
       fontWeight: 700,
     }}
-    className="nodrag nopan"
+    class="nodrag nopan"
   >
     {data.label}
   </div>


### PR DESCRIPTION
Copying this example into an editor just broke. I changed the imports and react-style className declaration.