### PR TITLE
fix(base-node): fix `BaseNode` demo code selection

### DIFF
--- a/apps/ui-components/registry/components/base-node/demo.tsx
+++ b/apps/ui-components/registry/components/base-node/demo.tsx
@@ -24,9 +24,9 @@ const nodeTypes = {
   customNode: CustomNode,
 };
 
-function CustomNode({ data }: NodeProps) {
+function CustomNode({ selected, data }: NodeProps) {
   return (
-    <BaseNode>
+    <BaseNode selected={selected}>
       <>
         {data.label}
         <Handle type="source" position={Position.Right} />


### PR DESCRIPTION
Currently the demo `CustomNode` of `BaseNode` on the official website (<https://reactflow.dev/components/nodes/base-node>) cannot be selected. This PR fixes this issue.

https://github.com/user-attachments/assets/ad7fd07d-f08c-4f75-aeed-7679c56abdec
