### PR TITLE
Fix broken link to BaseNode in node-header.mdx

### DIFF
--- a/sites/reactflow.dev/src/pages/components/nodes/node-header.mdx
+++ b/sites/reactflow.dev/src/pages/components/nodes/node-header.mdx
@@ -10,7 +10,7 @@ export const getStaticProps = fetchShadcnComponent('node-header');
 
 # Node Header
 
-A header designed to work with the [`<BaseNode />`](/components/base-node) component.
+A header designed to work with the [`<BaseNode />`](/components/nodes/base-node) component.
 It can contain a title, icon, and list of actions.
 
 <UiComponentViewer />


### PR DESCRIPTION
The link to `<BaseNode>` on the [Node Header](https://reactflow.dev/components/nodes/node-header) documentation page links to https://reactflow.dev/components/base-node and not https://reactflow.dev/components/nodes/base-node.