### PR TITLE
Fix ThrelteFlow example

### DIFF
--- a/apps/example-apps/svelte/examples/misc/threlte-flow/ThrelteScene.svelte
+++ b/apps/example-apps/svelte/examples/misc/threlte-flow/ThrelteScene.svelte
@@ -28,9 +28,9 @@
 
   $: $camera.position.set(0, 0, +$flowState.zoom);
 
-  let t: number;
-  useFrame(({ clock }) => {
-    t = clock.getElapsedTime();
+  let t = 0;
+  useFrame((ctx, delta) => {
+    t += delta;
   });
 </script>
 


### PR DESCRIPTION
`useFrame()` takes a callback that expects the time elapsed in seconds to be the second param.

https://github.com/grischaerbe/threlte/blob/9e5a30f7bddbc000907f032734923106d2a6bf56/packages/core/src/lib/hooks/useFrame.ts#L25