### PR TITLE
Remove misplaced `getStaticProps/getStaticCode`

### DIFF
--- a/sites/reactflow.dev/src/pages/learn/advanced-use/computing-flows.mdx
+++ b/sites/reactflow.dev/src/pages/learn/advanced-use/computing-flows.mdx
@@ -40,10 +40,6 @@ Let's start by creating a custom input node (`NumberInput.js`) and add three ins
 import { useCallback, useState } from 'react';
 import { Handle, Position } from '@xyflow/react';
 
-import { getStaticCode } from 'xy-shared/server';
-export const getStaticProps = getStaticCode(['learn/computing-6', 'learn/computing', 'learn/computing-2', 'learn/computing-3', 'learn/computing-4', 'learn/computing-5', 'learn/computing-6']);
-
-
 function NumberInput({ id, data }) {
   const [number, setNumber] = useState(0);
 


### PR DESCRIPTION
it's not related to this code block?  we wrote getStaticProps in https://github.com/dimaMachina/web/blob/a642195e1aeb5c36fb136076a2d647ef92b9fad7/sites/reactflow.dev/src/pages/learn/advanced-use/computing-flows.mdx?plain=1#L10-L19