### PR TITLE
docs: fix typo in node-header

### DIFF
--- a/apps/example-apps/react/tutorials/components/complete/components/node-header.tsx
+++ b/apps/example-apps/react/tutorials/components/complete/components/node-header.tsx
@@ -118,7 +118,7 @@ export interface NodeHeaderActionProps extends ButtonProps {
  * A thin wrapper around the `<Button />` component with a fixed sized suitable
  * for icons.
  *
- * Beacuse the `<NodeHeaderAction />` component is intended to render icons, it's
+ * Because the `<NodeHeaderAction />` component is intended to render icons, it's
  * important to provide a meaningful and accessible `label` prop that describes
  * the action.
  */

--- a/apps/example-apps/react/tutorials/components/num-node/components/node-header.tsx
+++ b/apps/example-apps/react/tutorials/components/num-node/components/node-header.tsx
@@ -118,7 +118,7 @@ export interface NodeHeaderActionProps extends ButtonProps {
  * A thin wrapper around the `<Button />` component with a fixed sized suitable
  * for icons.
  *
- * Beacuse the `<NodeHeaderAction />` component is intended to render icons, it's
+ * Because the `<NodeHeaderAction />` component is intended to render icons, it's
  * important to provide a meaningful and accessible `label` prop that describes
  * the action.
  */

--- a/apps/example-apps/react/tutorials/components/sum-node/components/node-header.tsx
+++ b/apps/example-apps/react/tutorials/components/sum-node/components/node-header.tsx
@@ -118,7 +118,7 @@ export interface NodeHeaderActionProps extends ButtonProps {
  * A thin wrapper around the `<Button />` component with a fixed sized suitable
  * for icons.
  *
- * Beacuse the `<NodeHeaderAction />` component is intended to render icons, it's
+ * Because the `<NodeHeaderAction />` component is intended to render icons, it's
  * important to provide a meaningful and accessible `label` prop that describes
  * the action.
  */

--- a/apps/ui-components/registry/components/node-header/index.tsx
+++ b/apps/ui-components/registry/components/node-header/index.tsx
@@ -116,7 +116,7 @@ export interface NodeHeaderActionProps extends ButtonProps {
  * A thin wrapper around the `<Button />` component with a fixed sized suitable
  * for icons.
  *
- * Beacuse the `<NodeHeaderAction />` component is intended to render icons, it's
+ * Because the `<NodeHeaderAction />` component is intended to render icons, it's
  * important to provide a meaningful and accessible `label` prop that describes
  * the action.
  */


### PR DESCRIPTION
Fix typoes (Beacuse → Because)