### PR TITLE
chore: fix width of homepage sections

### DIFF
--- a/packages/xy-shared/layouts/base.tsx
+++ b/packages/xy-shared/layouts/base.tsx
@@ -11,7 +11,7 @@ export function BaseLayout({ children, className }: BaseLayoutProps) {
   return (
     <main
       className={cn(
-        'pt-10 lg:pt-14 2xl:pt-18 pb-24 mx-auto max-w-[78rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]',
+        'pt-10 lg:pt-14 2xl:pt-18 pb-24 mx-auto x:max-w-(--nextra-content-width) pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]',
         className,
       )}
     >

--- a/packages/xy-shared/layouts/blog-post-base.tsx
+++ b/packages/xy-shared/layouts/blog-post-base.tsx
@@ -61,7 +61,7 @@ type BlogPostPreviewsProps = {
 function BlogPostPreviews({ prev, next }: BlogPostPreviewsProps) {
   return (
     <div className="mt-20 relative right-1/2 left-1/2 ml-[-50vw] mr-[-50vw] w-[100vw]">
-      <ContentGrid className="max-w-[90rem] mx-auto">
+      <ContentGrid className="x:max-w-(--nextra-content-width) mx-auto">
         {prev && (
           <ContentGridItem route={prev?.route}>
             <BlogPostPreview

--- a/packages/xy-shared/widgets/getting-started/index.tsx
+++ b/packages/xy-shared/widgets/getting-started/index.tsx
@@ -13,7 +13,7 @@ type GettingStartedProps = {
 
 function GettingStarted({ libraryName, packageName }: GettingStartedProps) {
   return (
-    <LayoutBreakout className="max-w-[78rem] lg:ml-0 lg:mr-0 lg:right-0 lg:left-0 lg:w-full lg:px-4 !mt-0">
+    <LayoutBreakout className="x:max-w-(--nextra-content-width) lg:ml-0 lg:mr-0 lg:right-0 lg:left-0 lg:w-full !mt-0">
       <Container
         variant="dark"
         className="rounded-none border-none p-0 mt-16 lg:mt-24 lg:p-1.5 lg:rounded-3xl"

--- a/packages/xy-shared/widgets/hero-flow/index.tsx
+++ b/packages/xy-shared/widgets/hero-flow/index.tsx
@@ -24,7 +24,7 @@ function HeroFlow({
 }: HeroFlowProps) {
   return (
     <LayoutBreakout className="h-[600px] lg:h-[550px] xl:h-[600px] -mt-10 lg:-mt-14 2xl:-mt-18">
-      <div className="pointer-events-none max-w-[90rem] w-full absolute left-1/2 top-8 lg:top-[130px] -translate-x-1/2 z-10">
+      <div className="pointer-events-none x:max-w-(--nextra-content-width) w-full absolute left-1/2 top-8 lg:top-[130px] -translate-x-1/2 z-10">
         <div
           style={headlineStyle}
           className="text-center mx-auto lg:mx-0 lg:text-left max-w-lg relative bg-white/10 backdrop-blur-[2px] px-3 lg:px-[35px]"

--- a/packages/xy-shared/widgets/hero-flow/index.tsx
+++ b/packages/xy-shared/widgets/hero-flow/index.tsx
@@ -29,7 +29,7 @@ function HeroFlow({
           style={headlineStyle}
           className="text-center mx-auto lg:mx-0 lg:text-left max-w-lg relative bg-white/10 backdrop-blur-[2px] px-3 lg:px-[35px]"
         >
-          <Heading size="lg" className="mb-4 font-black">
+          <Heading size="lg" as="h1" className="mb-4 font-black">
             Wire Your Ideas with <span className="text-primary">{title}</span>
           </Heading>
 

--- a/packages/xy-shared/widgets/hero/index.tsx
+++ b/packages/xy-shared/widgets/hero/index.tsx
@@ -38,7 +38,7 @@ export function Hero({
     <div ref={ref}>
       {backgroundVariant === 'gradient' && (
         <div
-          className="absolute -mt-16 opacity-10 w-[100vw] h-[70vw] left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none -z-10"
+          className="absolute -mt-16 opacity-10 w-[100vw] h-[70vw] left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
           style={{
             background:
               'radial-gradient(rgba(68,91,222,1) 0%, rgba(215,78,243,1) 25%, rgba(255,255,255,1) 50%)',
@@ -77,7 +77,7 @@ export function Hero({
             </h3>
           )}
           {title && (
-            <Heading size={size} className="mb-6 font-black">
+            <Heading as="h1" size={size} className="mb-6 font-black">
               {title}
             </Heading>
           )}

--- a/packages/xy-ui/components/ui/footer/index.tsx
+++ b/packages/xy-ui/components/ui/footer/index.tsx
@@ -54,7 +54,7 @@ const Footer = forwardRef<HTMLDivElement, FooterProps>(
   ) => {
     return (
       <footer className={cn(footerVariants({ variant, className }))} ref={ref}>
-        <div className="mx-auto lg:flex max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
+        <div className="mx-auto lg:flex x:max-w-(--nextra-content-width) pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
           <div className="lg:max-w-[300px] md:max-w-[600px] lg:mr-24 shrink-0">
             {message && (
               <>

--- a/packages/xy-ui/components/ui/heading.tsx
+++ b/packages/xy-ui/components/ui/heading.tsx
@@ -26,12 +26,12 @@ export interface HeadingProps
 }
 
 const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
-  ({ className, size, as: asProp = null, ...props }, ref) => {
-    const Comp = asProp ? asProp : 'h1';
+  ({ className, size, as: asProp = 'h2', ...props }, ref) => {
+    const Comp = asProp;
 
     return (
       <Comp
-        className={cn(headingSizes({ size, className }))}
+        className={cn(headingSizes({ size }), className)}
         ref={ref}
         {...props}
       />

--- a/packages/xy-ui/components/ui/section.tsx
+++ b/packages/xy-ui/components/ui/section.tsx
@@ -5,11 +5,7 @@ type SectionProps = React.HTMLAttributes<HTMLDivElement>;
 
 const Section = forwardRef<HTMLDivElement, SectionProps>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn('px-2 lg:px-4 my-16 lg:my-24', className)}
-      {...props}
-    />
+    <div ref={ref} className={cn('my-16 lg:my-24', className)} {...props} />
   ),
 );
 

--- a/sites/reactflow.dev/src/app/(content-pages)/page.tsx
+++ b/sites/reactflow.dev/src/app/(content-pages)/page.tsx
@@ -125,7 +125,7 @@ const Page: FC = async () => {
         }
       />
 
-      <Section className="mt-6 lg:mt-10 lg:px-5">
+      <Section className="mt-6 lg:mt-10 lg:px-10">
         <Stats
           stats={[
             { label: 'Github Stars', value: `${(stars / 1000).toFixed(1)}K` },

--- a/sites/reactflow.dev/src/app/(content-pages)/page.tsx
+++ b/sites/reactflow.dev/src/app/(content-pages)/page.tsx
@@ -125,7 +125,7 @@ const Page: FC = async () => {
         }
       />
 
-      <Section className="mt-6 lg:mt-10">
+      <Section className="mt-6 lg:mt-10 lg:px-5">
         <Stats
           stats={[
             { label: 'Github Stars', value: `${(stars / 1000).toFixed(1)}K` },

--- a/sites/reactflow.dev/src/app/(content-pages)/page.tsx
+++ b/sites/reactflow.dev/src/app/(content-pages)/page.tsx
@@ -159,6 +159,7 @@ const Page: FC = async () => {
 
       <Section className="relative">
         <WhatsNewPreview items={whatsNew} variant="compact" />
+
         <div className="lg:hidden h-[50%] w-full bg-gradient-to-b from-transparent via-white/70 to-white absolute bottom-0 pointer-events-none" />
       </Section>
 

--- a/sites/reactflow.dev/src/app/pro/examples/page.tsx
+++ b/sites/reactflow.dev/src/app/pro/examples/page.tsx
@@ -190,7 +190,7 @@ const ProExamples: FC = async () => {
       </ContentGrid>
 
       <Section className="lg:px-0">
-        <LayoutBreakout className="max-w-[78rem] lg:ml-0 lg:mr-0 lg:right-0 lg:left-0 lg:w-full lg:px-0 !mt-0">
+        <LayoutBreakout className="x:max-w-(--nextra-content-width) lg:ml-0 lg:mr-0 lg:right-0 lg:left-0 lg:w-full lg:px-0 !mt-0">
           <Container
             variant="dark"
             className="max-lg:rounded-none"


### PR DESCRIPTION
Widths of sections on the homepage should vertically align. I updated these values to all use the `--nextra-content-width` variable. Looks okay to me on the three sites but a second set of eyes would be good. 

![Screenshot 2025-03-04 at 10 58 29](https://github.com/user-attachments/assets/19ff54d8-1d43-4aac-9edd-63c257f28fb8)


* Headings should be `h2` unless main title of page