### PR TITLE
chore: add blog structure to whats-new posts

### DIFF
--- a/.github/workflows/createWhatsNew.yaml
+++ b/.github/workflows/createWhatsNew.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Determine current day & date
         id: date
         run: |
-          echo "DATE=$(date +'%Y-%m-%dT12:00:00')" >> $GITHUB_ENV
+          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
           echo "DAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Determine package version
         id: version

--- a/sites/reactflow.dev/src/app/(content-pages)/[...mdxPath]/page.tsx
+++ b/sites/reactflow.dev/src/app/(content-pages)/[...mdxPath]/page.tsx
@@ -3,6 +3,7 @@ import { BaseBlogPostLayout, CaseStudyLayoutWrapper } from 'xy-shared';
 import { useMDXComponents as getMdxComponents } from '@/mdx-components';
 import { normalizePages } from 'nextra/normalize-pages';
 import { getPageMap } from 'nextra/page-map';
+import { getWhatsNew } from '@/utils';
 
 type PageProps = Readonly<{
   params: Promise<{
@@ -58,6 +59,33 @@ export default async function Page(props: PageProps) {
             >
               {mdx}
             </CaseStudyLayoutWrapper>
+          );
+        }
+
+        const isWhatsNew = slug[0] === 'whats-new';
+        if (isWhatsNew) {
+          const pageMap = await getWhatsNew();
+          const route = ['/whats-new', ...slug.slice(1)].join('/');
+          const { activeIndex, flatDocsDirectories } = normalizePages({
+            list: pageMap,
+            route,
+          });
+          return (
+            <BaseBlogPostLayout
+              frontMatter={metadata}
+              prev={
+                activeIndex > 0
+                  ? flatDocsDirectories[activeIndex - 1]
+                  : undefined
+              }
+              next={
+                activeIndex < flatDocsDirectories.length - 1
+                  ? flatDocsDirectories[activeIndex + 1]
+                  : undefined
+              }
+            >
+              {mdx}
+            </BaseBlogPostLayout>
           );
         }
 

--- a/sites/reactflow.dev/src/content/whats-new/2024-09-12.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-09-12.mdx
@@ -2,7 +2,7 @@
 title: 'React Flow 12.3.0'
 description: 'Changelog for React Flow version 12.3.0'
 authors: [xyflow]
-date: '2024-09-12T12:00:00'
+date: '2024-09-12'
 ---
 
 # Whats New in React Flow 12.3.0

--- a/sites/reactflow.dev/src/content/whats-new/2024-10-10.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-10-10.mdx
@@ -1,11 +1,12 @@
 ---
-title: "React Flow 12.3.2"
-description: "Changelog for React Flow version 12.3.2"
+title: 'React Flow 12.3.2'
+description: 'Changelog for React Flow version 12.3.2'
 authors: [xyflow]
-date: '2024-10-10T12:00:00'
+date: '2024-10-10'
 ---
+
 # Whats New in React Flow 12.3.2
+
 ### Patch Changes
 
--   [#4722](https://github.com/xyflow/xyflow/pull/4722) Fix internal behaviour that mutated user nodes which led to an issue with Redux and immer
-
+- [#4722](https://github.com/xyflow/xyflow/pull/4722) Fix internal behaviour that mutated user nodes which led to an issue with Redux and immer

--- a/sites/reactflow.dev/src/content/whats-new/2024-10-30.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-10-30.mdx
@@ -1,11 +1,13 @@
 ---
-title: "React Flow 12.3.3"
-description: "Changelog for React Flow version 12.3.3"
+title: 'React Flow 12.3.3'
+description: 'Changelog for React Flow version 12.3.3'
 authors: [xyflow]
-date: '2024-10-30T12:00:00'
+date: '2024-10-30'
 ---
-# Whats New in React Flow 12.3.3
-### Patch Changes
--   [#4755](https://github.com/xyflow/xyflow/pull/4755) Add module to exports in package.json. This should resolve possible issues with Webpack ESM Module Resolution.
--   [#4730](https://github.com/xyflow/xyflow/pull/4730) Fixed rare crash while dragging
 
+# Whats New in React Flow 12.3.3
+
+### Patch Changes
+
+- [#4755](https://github.com/xyflow/xyflow/pull/4755) Add module to exports in package.json. This should resolve possible issues with Webpack ESM Module Resolution.
+- [#4730](https://github.com/xyflow/xyflow/pull/4730) Fixed rare crash while dragging

--- a/sites/reactflow.dev/src/content/whats-new/2024-10-31.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-10-31.mdx
@@ -1,10 +1,12 @@
 ---
-title: "React Flow 12.3.4"
-description: "Changelog for React Flow version 12.3.4"
+title: 'React Flow 12.3.4'
+description: 'Changelog for React Flow version 12.3.4'
 authors: [xyflow]
-date: '2024-10-31T12:00:00'
+date: '2024-10-31'
 ---
-# Whats New in React Flow 12.3.4
-### Patch Changes
--   [#4772](https://github.com/xyflow/xyflow/pull/4772) Thanks [@mistic](https://github.com/mistic)! - Splits exports field in package.json to support an explicit resolution for browser, node and default to resolve issues with webpack esm module resolution.
 
+# Whats New in React Flow 12.3.4
+
+### Patch Changes
+
+- [#4772](https://github.com/xyflow/xyflow/pull/4772) Thanks [@mistic](https://github.com/mistic)! - Splits exports field in package.json to support an explicit resolution for browser, node and default to resolve issues with webpack esm module resolution.

--- a/sites/reactflow.dev/src/content/whats-new/2024-11-04.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-11-04.mdx
@@ -4,7 +4,7 @@ description:
   We've been interested in developing reusable components for React Flow for a
   while now. With the recent releases of shadcn CLI, we've made that happen!
 authors: [xyflow]
-date: '2024-11-04T12:00:00'
+date: '2024-11-04'
 ---
 
 # Introducing React Flow Components - powered by shadcn CLI

--- a/sites/reactflow.dev/src/content/whats-new/2024-11-11.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-11-11.mdx
@@ -1,13 +1,15 @@
 ---
-title: "React Flow 12.3.5"
-description: "Changelog for React Flow version 12.3.5"
+title: 'React Flow 12.3.5'
+description: 'Changelog for React Flow version 12.3.5'
 authors: [xyflow]
-date: '2024-11-11T12:00:00'
+date: '2024-11-11'
 ---
-# Whats New in React Flow 12.3.5
-### Patch Changes
--   [#4789](https://github.com/xyflow/xyflow/pull/4789) Support key combinations which include + (e.g., Control++ resolves to the combination Control and +).
--   [#4796](https://github.com/xyflow/xyflow/pull/4796) Thanks [@Aki-7](https://github.com/Aki-7)! - Fix number of issues connected to batching node & edge updates.
--   [#4790](https://github.com/xyflow/xyflow/pull/4790) Fix node dragging & resizing while zooming on flow that does not cover whole browser window.
--   [#4782](https://github.com/xyflow/xyflow/pull/4782) Fix node intersections in nested flow.
 
+# Whats New in React Flow 12.3.5
+
+### Patch Changes
+
+- [#4789](https://github.com/xyflow/xyflow/pull/4789) Support key combinations which include + (e.g., Control++ resolves to the combination Control and +).
+- [#4796](https://github.com/xyflow/xyflow/pull/4796) Thanks [@Aki-7](https://github.com/Aki-7)! - Fix number of issues connected to batching node & edge updates.
+- [#4790](https://github.com/xyflow/xyflow/pull/4790) Fix node dragging & resizing while zooming on flow that does not cover whole browser window.
+- [#4782](https://github.com/xyflow/xyflow/pull/4782) Fix node intersections in nested flow.

--- a/sites/reactflow.dev/src/content/whats-new/2024-12-09.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2024-12-09.mdx
@@ -1,18 +1,20 @@
 ---
-title: "React Flow 12.3.6"
-description: "Changelog for React Flow version 12.3.6"
+title: 'React Flow 12.3.6'
+description: 'Changelog for React Flow version 12.3.6'
 authors: [xyflow]
-date: '2024-12-09T12:00:00'
+date: '2024-12-09'
 ---
-# Whats New in React Flow 12.3.6
-### Patch Changes
--   [#4846](https://github.com/xyflow/xyflow/pull/4846) Make it possible to use expandParent with immer and other immutable helpers
--   [#4865](https://github.com/xyflow/xyflow/pull/4865) Add group node to BuiltInNode type. Thanks [@sjdemartini](https://github.com/sjdemartini)!
--   [#4877](https://github.com/xyflow/xyflow/pull/4877) Fix intersections for nodes with origins other than [0,0]. Thanks [@gmvrpw](https://github.com/gmvrpw)!
--   [#4844](https://github.com/xyflow/xyflow/pull/4844) Allow custom data-testid for ReactFlow component
--   [#4816](https://github.com/xyflow/xyflow/pull/4816) Type isValidConnection prop correctly by passing EdgeType
--   [#4855](https://github.com/xyflow/xyflow/pull/4855) Thanks [@mhuggins](https://github.com/mhuggins)! - Support passing `path` element attributes to `BaseEdge` component.
--   [#4862](https://github.com/xyflow/xyflow/pull/4862) Prevent default scrolling behavior when nodes or a selection is moved with an arrow key press.
--   [#4875](https://github.com/xyflow/xyflow/pull/4875) Prevent unnecessary rerenders of edges when resizing the flow.
--   [#4826](https://github.com/xyflow/xyflow/pull/4826) Forward ref of the div inside Panel components.
 
+# Whats New in React Flow 12.3.6
+
+### Patch Changes
+
+- [#4846](https://github.com/xyflow/xyflow/pull/4846) Make it possible to use expandParent with immer and other immutable helpers
+- [#4865](https://github.com/xyflow/xyflow/pull/4865) Add group node to BuiltInNode type. Thanks [@sjdemartini](https://github.com/sjdemartini)!
+- [#4877](https://github.com/xyflow/xyflow/pull/4877) Fix intersections for nodes with origins other than [0,0]. Thanks [@gmvrpw](https://github.com/gmvrpw)!
+- [#4844](https://github.com/xyflow/xyflow/pull/4844) Allow custom data-testid for ReactFlow component
+- [#4816](https://github.com/xyflow/xyflow/pull/4816) Type isValidConnection prop correctly by passing EdgeType
+- [#4855](https://github.com/xyflow/xyflow/pull/4855) Thanks [@mhuggins](https://github.com/mhuggins)! - Support passing `path` element attributes to `BaseEdge` component.
+- [#4862](https://github.com/xyflow/xyflow/pull/4862) Prevent default scrolling behavior when nodes or a selection is moved with an arrow key press.
+- [#4875](https://github.com/xyflow/xyflow/pull/4875) Prevent unnecessary rerenders of edges when resizing the flow.
+- [#4826](https://github.com/xyflow/xyflow/pull/4826) Forward ref of the div inside Panel components.

--- a/sites/reactflow.dev/src/content/whats-new/2025-01-15.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2025-01-15.mdx
@@ -1,18 +1,20 @@
 ---
-title: "React Flow 12.4.0"
-description: "Changelog for React Flow version 12.4.0"
+title: 'React Flow 12.4.0'
+description: 'Changelog for React Flow version 12.4.0'
 authors: [xyflow]
-date: '2025-01-15T12:00:00'
+date: '2025-01-15'
 ---
+
 # Whats New in React Flow 12.4.0
 
-New year, new minor release :) This release contains mostly fixes but also introduces a new [`useNodeConnections`](/api-reference/hooks/use-node-connections) that is the successor of `useHandleConnections`. 
+New year, new minor release :) This release contains mostly fixes but also introduces a new [`useNodeConnections`](/api-reference/hooks/use-node-connections) that is the successor of `useHandleConnections`.
 
 ### Minor Changes
--   [#4725](https://github.com/xyflow/xyflow/pull/4725) Add `useNodeConnections` hook to track all connections to a node. Can be filtered by handleType and handleId.
+
+- [#4725](https://github.com/xyflow/xyflow/pull/4725) Add `useNodeConnections` hook to track all connections to a node. Can be filtered by handleType and handleId.
 
 ### Patch Changes
--   [#4947](https://github.com/xyflow/xyflow/pull/4947) Export ResizeControlVariant correctly as a value.
--   [#4880](https://github.com/xyflow/xyflow/pull/4880) Thanks [@crimx](https://github.com/crimx)! - Add type check for all event targets
--   [#4929](https://github.com/xyflow/xyflow/pull/4929) Optimize selections and take into account if edges connected to selected nodes are actually selectable.
 
+- [#4947](https://github.com/xyflow/xyflow/pull/4947) Export ResizeControlVariant correctly as a value.
+- [#4880](https://github.com/xyflow/xyflow/pull/4880) Thanks [@crimx](https://github.com/crimx)! - Add type check for all event targets
+- [#4929](https://github.com/xyflow/xyflow/pull/4929) Optimize selections and take into account if edges connected to selected nodes are actually selectable.

--- a/sites/reactflow.dev/src/content/whats-new/2025-01-16.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2025-01-16.mdx
@@ -1,10 +1,12 @@
 ---
-title: "React Flow 12.4.1"
-description: "Changelog for React Flow version 12.4.1"
+title: 'React Flow 12.4.1'
+description: 'Changelog for React Flow version 12.4.1'
 authors: [xyflow]
-date: '2025-01-16T12:00:00'
+date: '2025-01-16'
 ---
-# Whats New in React Flow 12.4.1
-### Patch Changes
--   [#4949](https://github.com/xyflow/xyflow/pull/4949) Fix useNodeConnection hook not returning all connected edges.
 
+# Whats New in React Flow 12.4.1
+
+### Patch Changes
+
+- [#4949](https://github.com/xyflow/xyflow/pull/4949) Fix useNodeConnection hook not returning all connected edges.

--- a/sites/reactflow.dev/src/content/whats-new/2025-01-21.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2025-01-21.mdx
@@ -1,11 +1,12 @@
 ---
-title: "React Flow 12.4.2"
-description: "Changelog for React Flow version 12.4.2"
+title: 'React Flow 12.4.2'
+description: 'Changelog for React Flow version 12.4.2'
 authors: [xyflow]
-date: '2025-01-21T12:00:00'
+date: '2025-01-21'
 ---
+
 # Whats New in React Flow 12.4.2
 
 ### Patch Changes
--   [#4957](https://github.com/xyflow/xyflow/pull/4957) Narrow properties selected, selectable, deletable, draggable of NodeProps type to be required.
 
+- [#4957](https://github.com/xyflow/xyflow/pull/4957) Narrow properties selected, selectable, deletable, draggable of NodeProps type to be required.

--- a/sites/reactflow.dev/src/content/whats-new/2025-02-12.mdx
+++ b/sites/reactflow.dev/src/content/whats-new/2025-02-12.mdx
@@ -1,16 +1,18 @@
 ---
-title: "React Flow 12.4.3"
-description: "Changelog for React Flow version 12.4.3"
+title: 'React Flow 12.4.3'
+description: 'Changelog for React Flow version 12.4.3'
 authors: [xyflow]
-date: '2025-02-12T12:00:00'
+date: '2025-02-12'
 ---
-# Whats New in React Flow 12.4.3
-### Patch Changes
--   [#5010](https://github.com/xyflow/xyflow/pull/5010) Add more TSDocs to components, hooks, utils funcs and types
--   [#4991](https://github.com/xyflow/xyflow/pull/4991) Thanks [@waynetee](https://github.com/waynetee)! - Fix viewport shifting on node focus
--   [#5013](https://github.com/xyflow/xyflow/pull/5013) Pass `NodeType` type argument from `ReactFlowProps` to `connectionLineComponent` property.
--   [#5008](https://github.com/xyflow/xyflow/pull/5008) Add package.json to exports
--   [#5012](https://github.com/xyflow/xyflow/pull/5012) Add snapGrid option to screenToFlowPosition and set snapToGrid to false
--   [#5003](https://github.com/xyflow/xyflow/pull/5003) Thanks [@dimaMachina](https://github.com/dimaMachina)! - repair lint command
--   [#4991](https://github.com/xyflow/xyflow/pull/4991) Thanks [@waynetee](https://github.com/waynetee)! - Prevent viewport shift after using Tab
 
+# Whats New in React Flow 12.4.3
+
+### Patch Changes
+
+- [#5010](https://github.com/xyflow/xyflow/pull/5010) Add more TSDocs to components, hooks, utils funcs and types
+- [#4991](https://github.com/xyflow/xyflow/pull/4991) Thanks [@waynetee](https://github.com/waynetee)! - Fix viewport shifting on node focus
+- [#5013](https://github.com/xyflow/xyflow/pull/5013) Pass `NodeType` type argument from `ReactFlowProps` to `connectionLineComponent` property.
+- [#5008](https://github.com/xyflow/xyflow/pull/5008) Add package.json to exports
+- [#5012](https://github.com/xyflow/xyflow/pull/5012) Add snapGrid option to screenToFlowPosition and set snapToGrid to false
+- [#5003](https://github.com/xyflow/xyflow/pull/5003) Thanks [@dimaMachina](https://github.com/dimaMachina)! - repair lint command
+- [#4991](https://github.com/xyflow/xyflow/pull/4991) Thanks [@waynetee](https://github.com/waynetee)! - Prevent viewport shift after using Tab

--- a/sites/reactflow.dev/src/utils/get-whats-new.ts
+++ b/sites/reactflow.dev/src/utils/get-whats-new.ts
@@ -1,0 +1,13 @@
+import { getPageMap } from 'nextra/page-map';
+import { MdxFile } from 'nextra';
+
+export async function getWhatsNew() {
+  const pageMap = (await getPageMap('/whats-new')) as MdxFile[];
+  return pageMap
+    .filter((item) => 'frontMatter' in item)
+    .sort(
+      (a, b) =>
+        new Date(b.frontMatter.date).getTime() -
+        new Date(a.frontMatter.date).getTime(),
+    );
+}

--- a/sites/reactflow.dev/src/utils/index.ts
+++ b/sites/reactflow.dev/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './routes';
 export * from './fetch-github-npm-stats';
 export * from './fetch-shadcn-component';
+export * from './get-whats-new';

--- a/sites/reactflow.dev/src/utils/routes.ts
+++ b/sites/reactflow.dev/src/utils/routes.ts
@@ -249,4 +249,5 @@ export type InternalRoute =
   | '/whats-new/2024-09-12'
   | '/whats-new/2024-09-26'
   | '/whats-new/2024-10-10'
-  | '/whats-new/2024-11-04';
+  | '/whats-new/2024-11-04'
+  | '/whats-new/2025-02-12';

--- a/sites/svelteflow.dev/src/content/whats-new/2024-06-10.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-06-10.mdx
@@ -2,7 +2,7 @@
 title: Svelte Flow 0.1.5 & 0.1.4
 description: Update for Svelte Flow
 authors: [peter]
-date: '2024-06-10T12:00:00'
+date: '2024-06-10'
 ---
 
 # Svelte Flow 0.1.5 & 0.1.4

--- a/sites/svelteflow.dev/src/content/whats-new/2024-09-12.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-09-12.mdx
@@ -1,14 +1,16 @@
 ---
-title: "Svelte Flow 0.1.19"
-description: "Changelog for Svelte Flow version 0.1.19"
+title: 'Svelte Flow 0.1.19'
+description: 'Changelog for Svelte Flow version 0.1.19'
 authors: [xyflow]
-date: '2024-09-12T12:00:00'
+date: '2024-09-12'
 ---
+
 # Whats New in Svelte Flow 0.1.19
+
 ### Patch Changes
 
--   [#4477](https://github.com/xyflow/xyflow/pull/4477) [`d5592e75`](https://github.com/xyflow/xyflow/commit/d5592e7508bc32d5ffc953844b1d42b9ec59b25b) Add `getNodesBounds` to `useReactFlow`/`useSvelteFlow` hook as the new recommended way of determining node bounds.
+- [#4477](https://github.com/xyflow/xyflow/pull/4477) [`d5592e75`](https://github.com/xyflow/xyflow/commit/d5592e7508bc32d5ffc953844b1d42b9ec59b25b) Add `getNodesBounds` to `useReactFlow`/`useSvelteFlow` hook as the new recommended way of determining node bounds.
 
--   [#4572](https://github.com/xyflow/xyflow/pull/4572) [`1445e148`](https://github.com/xyflow/xyflow/commit/1445e1483118c966ff6de3f29c5473c93f6b99f1) Add nodeExtent prop to `<SvelteFlow />`. You can now restrict nodes from leaving a specified extent.
+- [#4572](https://github.com/xyflow/xyflow/pull/4572) [`1445e148`](https://github.com/xyflow/xyflow/commit/1445e1483118c966ff6de3f29c5473c93f6b99f1) Add nodeExtent prop to `<SvelteFlow />`. You can now restrict nodes from leaving a specified extent.
 
--   [#4572](https://github.com/xyflow/xyflow/pull/4572) [`d9563505`](https://github.com/xyflow/xyflow/commit/d9563505d8fb01862a3a6bae6e05dcea626c2e26) Improve handling of global and individual `nodeExtent`s. Nodes will never render outside of specified extents.
+- [#4572](https://github.com/xyflow/xyflow/pull/4572) [`d9563505`](https://github.com/xyflow/xyflow/commit/d9563505d8fb01862a3a6bae6e05dcea626c2e26) Improve handling of global and individual `nodeExtent`s. Nodes will never render outside of specified extents.

--- a/sites/svelteflow.dev/src/content/whats-new/2024-10-10.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-10-10.mdx
@@ -1,11 +1,12 @@
 ---
-title: "Svelte Flow 0.1.21"
-description: "Changelog for Svelte Flow version 0.1.21"
+title: 'Svelte Flow 0.1.21'
+description: 'Changelog for Svelte Flow version 0.1.21'
 authors: [xyflow]
-date: '2024-10-10T12:00:00'
+date: '2024-10-10'
 ---
+
 # Whats New in Svelte Flow 0.1.21
+
 ### Patch Changes
 
--   [#4718](https://github.com/xyflow/xyflow/pull/4718) Fixed hook useNodesData unexpectedly returning undefined
-
+- [#4718](https://github.com/xyflow/xyflow/pull/4718) Fixed hook useNodesData unexpectedly returning undefined

--- a/sites/svelteflow.dev/src/content/whats-new/2024-10-30.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-10-30.mdx
@@ -1,11 +1,13 @@
 ---
-title: "Svelte Flow 0.1.22"
-description: "Changelog for Svelte Flow version 0.1.22"
+title: 'Svelte Flow 0.1.22'
+description: 'Changelog for Svelte Flow version 0.1.22'
 authors: [xyflow]
-date: '2024-10-30T12:00:00'
+date: '2024-10-30'
 ---
-# Whats New in Svelte Flow 0.1.22
-### Patch Changes
--   [#4730](https://github.com/xyflow/xyflow/pull/4730) Fixed rare crash while dragging
--   [#4758](https://github.com/xyflow/xyflow/pull/4758) Bump Svelte peer dependency to 5.0.0
 
+# Whats New in Svelte Flow 0.1.22
+
+### Patch Changes
+
+- [#4730](https://github.com/xyflow/xyflow/pull/4730) Fixed rare crash while dragging
+- [#4758](https://github.com/xyflow/xyflow/pull/4758) Bump Svelte peer dependency to 5.0.0

--- a/sites/svelteflow.dev/src/content/whats-new/2024-11-11.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-11-11.mdx
@@ -1,11 +1,13 @@
 ---
-title: "Svelte Flow 0.1.24"
-description: "Changelog for Svelte Flow version 0.1.24"
+title: 'Svelte Flow 0.1.24'
+description: 'Changelog for Svelte Flow version 0.1.24'
 authors: [xyflow]
-date: '2024-11-11T12:00:00'
+date: '2024-11-11'
 ---
-# Whats New in Svelte Flow 0.1.24
-### Patch Changes
--   [#4790](https://github.com/xyflow/xyflow/pull/4790) Fix node dragging & resizing while zooming on flow that does not cover whole browser window.
--   [#4782](https://github.com/xyflow/xyflow/pull/4782) Fix node intersections in nested flow.
 
+# Whats New in Svelte Flow 0.1.24
+
+### Patch Changes
+
+- [#4790](https://github.com/xyflow/xyflow/pull/4790) Fix node dragging & resizing while zooming on flow that does not cover whole browser window.
+- [#4782](https://github.com/xyflow/xyflow/pull/4782) Fix node intersections in nested flow.

--- a/sites/svelteflow.dev/src/content/whats-new/2024-12-09.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-12-09.mdx
@@ -1,11 +1,13 @@
 ---
-title: "Svelte Flow 0.1.25"
-description: "Changelog for Svelte Flow version 0.1.25"
+title: 'Svelte Flow 0.1.25'
+description: 'Changelog for Svelte Flow version 0.1.25'
 authors: [xyflow]
-date: '2024-12-09T12:00:00'
+date: '2024-12-09'
 ---
-# Whats New in Svelte Flow 0.1.25
-### Patch Changes
--   [#4865](https://github.com/xyflow/xyflow/pull/4865) Add group node to BuiltInNode type. Thanks [@sjdemartini](https://github.com/sjdemartini)!
--   [#4877](https://github.com/xyflow/xyflow/pull/4877) Fix intersections for nodes with origins other than [0,0]. Thanks [@gmvrpw](https://github.com/gmvrpw)!
 
+# Whats New in Svelte Flow 0.1.25
+
+### Patch Changes
+
+- [#4865](https://github.com/xyflow/xyflow/pull/4865) Add group node to BuiltInNode type. Thanks [@sjdemartini](https://github.com/sjdemartini)!
+- [#4877](https://github.com/xyflow/xyflow/pull/4877) Fix intersections for nodes with origins other than [0,0]. Thanks [@gmvrpw](https://github.com/gmvrpw)!

--- a/sites/svelteflow.dev/src/content/whats-new/2024-12-18.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2024-12-18.mdx
@@ -1,10 +1,12 @@
 ---
-title: "Svelte Flow 0.1.26"
-description: "Changelog for Svelte Flow version 0.1.26"
+title: 'Svelte Flow 0.1.26'
+description: 'Changelog for Svelte Flow version 0.1.26'
 authors: [xyflow]
-date: '2024-12-18T12:00:00'
+date: '2024-12-18'
 ---
-# Whats New in Svelte Flow 0.1.26
-### Patch Changes
--   [#4897](https://github.com/xyflow/xyflow/pull/4897) Freeze required @svelte-put/shortcut version to 3.1.1 to prevent breaking of key inputs.
 
+# Whats New in Svelte Flow 0.1.26
+
+### Patch Changes
+
+- [#4897](https://github.com/xyflow/xyflow/pull/4897) Freeze required @svelte-put/shortcut version to 3.1.1 to prevent breaking of key inputs.

--- a/sites/svelteflow.dev/src/content/whats-new/2025-01-15.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2025-01-15.mdx
@@ -1,13 +1,15 @@
 ---
-title: "Svelte Flow 0.1.27"
-description: "Changelog for Svelte Flow version 0.1.27"
+title: 'Svelte Flow 0.1.27'
+description: 'Changelog for Svelte Flow version 0.1.27'
 authors: [xyflow]
-date: '2025-01-15T12:00:00'
+date: '2025-01-15'
 ---
-# Whats New in Svelte Flow 0.1.27
-### Patch Changes
--   [#4937](https://github.com/xyflow/xyflow/pull/4937) Thanks [@jrmoynihan](https://github.com/jrmoynihan)! - Expose props of Controls
--   [#4947](https://github.com/xyflow/xyflow/pull/4947) Export ResizeControlVariant correctly as a value.
--   [#4880](https://github.com/xyflow/xyflow/pull/4880) Thanks [@crimx](https://github.com/crimx)! - Add type check for all event targets
--   [#4725](https://github.com/xyflow/xyflow/pull/4725) Add useNodeConnections hook to track all connections to a node. Can be filtered by handleType and handleId.
 
+# Whats New in Svelte Flow 0.1.27
+
+### Patch Changes
+
+- [#4937](https://github.com/xyflow/xyflow/pull/4937) Thanks [@jrmoynihan](https://github.com/jrmoynihan)! - Expose props of Controls
+- [#4947](https://github.com/xyflow/xyflow/pull/4947) Export ResizeControlVariant correctly as a value.
+- [#4880](https://github.com/xyflow/xyflow/pull/4880) Thanks [@crimx](https://github.com/crimx)! - Add type check for all event targets
+- [#4725](https://github.com/xyflow/xyflow/pull/4725) Add useNodeConnections hook to track all connections to a node. Can be filtered by handleType and handleId.

--- a/sites/svelteflow.dev/src/content/whats-new/2025-01-16.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2025-01-16.mdx
@@ -1,10 +1,12 @@
 ---
-title: "Svelte Flow 0.1.28"
-description: "Changelog for Svelte Flow version 0.1.28"
+title: 'Svelte Flow 0.1.28'
+description: 'Changelog for Svelte Flow version 0.1.28'
 authors: [xyflow]
-date: '2025-01-16T12:00:00'
+date: '2025-01-16'
 ---
-# Whats New in Svelte Flow 0.1.28
-### Patch Changes
--   [#4949](https://github.com/xyflow/xyflow/pull/4949) Fix useNodeConnection hook not returning all connected edges.
 
+# Whats New in Svelte Flow 0.1.28
+
+### Patch Changes
+
+- [#4949](https://github.com/xyflow/xyflow/pull/4949) Fix useNodeConnection hook not returning all connected edges.

--- a/sites/svelteflow.dev/src/content/whats-new/2025-01-21.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2025-01-21.mdx
@@ -1,10 +1,12 @@
 ---
-title: "Svelte Flow 0.1.29"
-description: "Changelog for Svelte Flow version 0.1.29"
+title: 'Svelte Flow 0.1.29'
+description: 'Changelog for Svelte Flow version 0.1.29'
 authors: [xyflow]
-date: '2025-01-21T12:00:00'
+date: '2025-01-21'
 ---
-# Whats New in Svelte Flow 0.1.29
-### Patch Changes
--   [#4957](https://github.com/xyflow/xyflow/pull/4957) Narrow properties selected, selectable, deletable, draggable of NodeProps type to be required.
 
+# Whats New in Svelte Flow 0.1.29
+
+### Patch Changes
+
+- [#4957](https://github.com/xyflow/xyflow/pull/4957) Narrow properties selected, selectable, deletable, draggable of NodeProps type to be required.

--- a/sites/svelteflow.dev/src/content/whats-new/2025-02-12.mdx
+++ b/sites/svelteflow.dev/src/content/whats-new/2025-02-12.mdx
@@ -1,10 +1,12 @@
 ---
-title: "Svelte Flow 0.1.30"
-description: "Changelog for Svelte Flow version 0.1.30"
+title: 'Svelte Flow 0.1.30'
+description: 'Changelog for Svelte Flow version 0.1.30'
 authors: [xyflow]
-date: '2025-02-12T12:00:00'
+date: '2025-02-12'
 ---
-# Whats New in Svelte Flow 0.1.30
-### Patch Changes
--   [#5010](https://github.com/xyflow/xyflow/pull/5010) Add more TSDocs to components, hooks, utils funcs and types
 
+# Whats New in Svelte Flow 0.1.30
+
+### Patch Changes
+
+- [#5010](https://github.com/xyflow/xyflow/pull/5010) Add more TSDocs to components, hooks, utils funcs and types


### PR DESCRIPTION
Previously, Whats New posts would just render the mdx file to the page. Now, they're wrapped in the same layout as the blog posts and have before/after links