### PR TITLE
fix `ControlsProps` typo

### DIFF
--- a/sites/reactflow.dev/src/content/api-reference/components/controls.mdx
+++ b/sites/reactflow.dev/src/content/api-reference/components/controls.mdx
@@ -31,7 +31,7 @@ export default function Flow() {
 ## Props
 
 For TypeScript users, the props type for the `<Controls />` component is exported
-as `ControlsProps`.
+as `ControlProps`.
 
 <PropsTable {...controlsProps} />
 

--- a/sites/svelteflow.dev/src/content/api-reference/components/controls.mdx
+++ b/sites/svelteflow.dev/src/content/api-reference/components/controls.mdx
@@ -33,7 +33,7 @@ buttons to zoom in, zoom out, fit the view, and lock the viewport.
 ## Props
 
 For TypeScript users, the props type for the `<Controls />` component is exported
-as `ControlsProps`.
+as `ControlProps`.
 
 <PropsTable {...controlsProps} />
 

--- a/sites/svelteflow.dev/src/content/api-reference/components/controls.mdx
+++ b/sites/svelteflow.dev/src/content/api-reference/components/controls.mdx
@@ -33,7 +33,7 @@ buttons to zoom in, zoom out, fit the view, and lock the viewport.
 ## Props
 
 For TypeScript users, the props type for the `<Controls />` component is exported
-as `ControlProps`.
+as `ControlsProps`.
 
 <PropsTable {...controlsProps} />
 


### PR DESCRIPTION
`@xyflow/react` has `ControlProps` but `@xyflow/svelte` `ControlsProps`

https://github.com/xyflow/xyflow/blob/c4adfcfa8a21197858e44be41f7d231c654004fe/packages/react/src/additional-components/Controls/types.ts#L9

https://github.com/xyflow/xyflow/blob/c4adfcfa8a21197858e44be41f7d231c654004fe/packages/svelte/src/lib/plugins/Controls/types.ts#L6