### PR TITLE
Fix minor typo in `TypeScript` docs

### DIFF
--- a/sites/reactflow.dev/src/content/learn/advanced-use/typescript.mdx
+++ b/sites/reactflow.dev/src/content/learn/advanced-use/typescript.mdx
@@ -28,7 +28,6 @@ import {
   type OnNodesChange,
   type OnEdgesChange,
   type OnNodeDrag,
-  type NodeTypes,
   type DefaultEdgeOptions,
 } from '@xyflow/react';
 
@@ -72,7 +71,6 @@ function Flow() {
     <ReactFlow
       nodes={nodes}
       edges={edges}
-      edgeTypes={edgeTypes}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onConnect={onConnect}


### PR DESCRIPTION
## Minor typo

Noticed a minor typo in demo code here: https://reactflow.dev/learn/advanced-use/typescript

<img width="800" alt="image" src="https://github.com/user-attachments/assets/485a91be-db14-4d54-a4c9-fcfc198f8055" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/6db6aeb7-2b90-4017-95de-4a3f59fbe9fc" />
