### PR TITLE
Update use-on-selection-change.mdx

### DIFF
--- a/sites/reactflow.dev/src/content/api-reference/hooks/use-on-selection-change.mdx
+++ b/sites/reactflow.dev/src/content/api-reference/hooks/use-on-selection-change.mdx
@@ -5,7 +5,6 @@ description:
   either nodes or edges changes.'
 ---
 
-import { Callout } from 'nextra/components';
 import { PropsTable } from '@/components/props-table';
 import { signature } from '@/references/hooks/useOnSelectionChange';
 
@@ -17,10 +16,10 @@ This hook lets you listen for changes to both node and edge selection. As the
 name implies, the callback you provide will be called whenever the selection of
 _either_ nodes or edges changes.
 
-<Callout type="info">
-  You need to memoize the passed `onChange` handler, otherwise the hook will not
-  work correctly.
-</Callout>
+> [!WARNING]
+>
+>  You need to memoize the passed `onChange` handler, otherwise the hook will not
+>  work correctly.
 
 ```jsx
 import { useState } from 'react';


### PR DESCRIPTION
this should be `warning` and not `info`, it uses github alert syntax from nextra 4 https://nextra.site/docs/guide/github-alert-syntax