### PR TITLE
Chore: Update testing.mdx to include setting panOnDrag=false to disable d3-drag

### DIFF
--- a/sites/reactflow.dev/src/content/learn/advanced-use/testing.mdx
+++ b/sites/reactflow.dev/src/content/learn/advanced-use/testing.mdx
@@ -78,5 +78,5 @@ export const mockReactFlow = () => {
 If you want to test mouse events with jest (for example inside your custom nodes), you need to disable `d3-drag` as it does not work outside of the browser:
 
 ```js
-<ReactFlow nodesDraggable={false} {...rest} />
+<ReactFlow nodesDraggable={false} panOnDrag={false} {...rest} />
 ```


### PR DESCRIPTION
Taking from [this comment ](https://github.com/xyflow/xyflow/issues/2461#issuecomment-2163004273), It is a good idea to include `panOnDrag={false}` in the testing documentation