### PR TITLE
Fix Svelte/CustomEdge EdgeLabel usage

### DIFF
--- a/apps/example-apps/svelte/examples/edges/custom-edges/ButtonEdge.svelte
+++ b/apps/example-apps/svelte/examples/edges/custom-edges/ButtonEdge.svelte
@@ -2,9 +2,9 @@
   import {
     getBezierPath,
     BaseEdge,
-    EdgeLabel,
-    useEdges,
     type EdgeProps,
+    useEdges,
+    EdgeLabel,
   } from '@xyflow/svelte';
 
   let {
@@ -31,17 +31,12 @@
   );
 
   const edges = useEdges();
-  const onEdgeClick = () => {
+
+  const onEdgeClick = () =>
     edges.update((eds) => eds.filter((edge) => edge.id !== id));
-  };
 </script>
 
 <BaseEdge path={edgePath} {markerEnd} {style} />
-<EdgeLabel>
-  <div
-    class="button-edge__label nodrag nopan"
-    style:transform="translate(-50%, -50%) translate({labelX}px,{labelY}px)"
-  >
-    <button class="button-edge__button" onclick={onEdgeClick}> × </button>
-  </div>
+<EdgeLabel x={labelX} y={labelY} class="button-edge__label">
+  <button class="button-edge__button" onclick={onEdgeClick}> × </button>
 </EdgeLabel>


### PR DESCRIPTION
I migrated my custom edge to the `EdgeLabel` API and encountered a weird white dot.
![my application](https://github.com/user-attachments/assets/8598739b-9eb7-40b3-8f4c-d7665811e871)

Looking at the sample on the website I originally copied my component from, I found it to suffer from the same issue, with a lesser visual impact due to the low contrast between the background and the color of the dot.
![example on website](https://github.com/user-attachments/assets/2b9e1063-8577-4f2a-b576-638f8637da74)

According to the [migration guide](https://svelteflow.dev/learn/troubleshooting/migrate-to-v1#edgelabelrenderer-becomes-edgelabel-), I was using the `EdgeLabel` component incorrectly.

This PR syncs said example with the https://github.com/xyflow/web/blob/main/apps/example-apps/svelte/guides/concepts/ButtonEdge.svelte component which seems to have been migrated correctly.