### PR TITLE
fix Svelte Flow quickstart graph fullscreening

### DIFF
--- a/sites/svelteflow.dev/src/content/learn/index.mdx
+++ b/sites/svelteflow.dev/src/content/learn/index.mdx
@@ -104,7 +104,7 @@ There are a few things to pay attention to here:
   ]);
 </script>
 
-<div style:width="100vh" style:height="100vh">
+<div style:width="100vw" style:height="100vh">
   <SvelteFlow bind:nodes bind:edges />
 </div>
 ```


### PR DESCRIPTION
Fixes a typo where the quickstart graph width is set to 100vh; this changes it to 100vw