### PR TITLE
Fix documentation links pointing to localhost

### DIFF
--- a/sites/reactflow.dev/src/content/learn/concepts/terms-and-definitions.mdx
+++ b/sites/reactflow.dev/src/content/learn/concepts/terms-and-definitions.mdx
@@ -22,7 +22,7 @@ A handle (also known as a “port” in other libraries) is the attachment point
 
 ### Edges
 
-Edges connect nodes. Every edge needs a target and a source node. React Flow comes with four built-in [edge types](http://localhost:3002/examples/edges/edge-types): default (bezier), smoothstep, step, and straight. An edge is SVG path that can be styled with CSS and is completely customizable. If you are using multiple handles, you can reference them individually to create multiple connections for a node.
+Edges connect nodes. Every edge needs a target and a source node. React Flow comes with four built-in [edge types](/examples/edges/edge-types): default (bezier), smoothstep, step, and straight. An edge is SVG path that can be styled with CSS and is completely customizable. If you are using multiple handles, you can reference them individually to create multiple connections for a node.
 
 Like custom nodes, you can also customize edges. Things that people do with custom edges include:
 
@@ -30,11 +30,11 @@ Like custom nodes, you can also customize edges. Things that people do with cust
 - Custom routing behavior
 - Complex styling or interactions that cannot be solved with just one SVG path
 
-For more information, refer to the [Custom Edges Reference](http://localhost:3002/api-reference/types/edge-props) page.
+For more information, refer to the [Custom Edges Reference](/api-reference/types/edge-props) page.
 
 ### Connection Line
 
-React Flow has built-in functionality that allows you to click and drag from one handle to another to create a new edge. While dragging, the placeholder edge is referred to as a connection line. The connection line also comes with four types built in and is customizable. You can find the props for configuring the connection line in the [props section](http://localhost:3002/api-reference/react-flow#connection-line-props).
+React Flow has built-in functionality that allows you to click and drag from one handle to another to create a new edge. While dragging, the placeholder edge is referred to as a connection line. The connection line also comes with four types built in and is customizable. You can find the props for configuring the connection line in the [props section](/api-reference/react-flow#connection-line-props).
 
 ### Viewport
 


### PR DESCRIPTION
Some links in the docs were hardcoded to localhost. This PR updates them to the correct URLs.