### PR TITLE
Fix incorrect prop name in custom edge example (`path` → `edgePath`)

### DIFF
--- a/sites/svelteflow.dev/src/content/learn/customization/custom-edges.mdx
+++ b/sites/svelteflow.dev/src/content/learn/customization/custom-edges.mdx
@@ -121,7 +121,7 @@ to:
   const edges = useEdges();
 </script>
 
-<BaseEdge {id} {path} />
+<BaseEdge {id} path={edgePath} />
 <EdgeLabel x={labelX} y={labelY}>
   <button
     class="nodrag nopan"


### PR DESCRIPTION
This updates the custom edge example in the Svelte Flow docs to use the correct prop: `<BaseEdge {id} path={edgePath} />` instead of `<BaseEdge {id} {path} />`.