### PR TITLE
fix(use-store): simplify selector function

### DIFF
--- a/sites/reactflow.dev/src/content/api-reference/hooks/use-store.mdx
+++ b/sites/reactflow.dev/src/content/api-reference/hooks/use-store.mdx
@@ -87,13 +87,5 @@ This hook can be typed by typing the selector function. See this
 [section in our TypeScript guide](/learn/advanced-use/typescript#nodetype-edgetype-unions) for more information.
 
 ```tsx
-const nodes = useStore((s: ReactFlowState<CustomNodeType>) => ({
-  nodes: s.nodes,
-}));
+const nodes = useStore((s: ReactFlowState<CustomNodeType>) => s.nodes);
 ```
-
-## Notes
-
-- You should define your store selector function _outside_ of the component that
-  uses it, or use React's `useCallback` hook to memoize the function. Not doing
-  this can incur a slight performance penalty.

--- a/sites/reactflow.dev/src/content/learn/advanced-use/typescript.mdx
+++ b/sites/reactflow.dev/src/content/learn/advanced-use/typescript.mdx
@@ -216,9 +216,7 @@ export default function FlowComponent() {
   const { getNodes, getEdges } = useReactFlow<CustomNodeType, CustomEdgeType>();
 
   // You can type useStore by typing the selector function
-  const nodes = useStore((s: ReactFlowState<CustomNodeType>) => ({
-    nodes: s.nodes,
-  }));
+  const nodes = useStore((s: ReactFlowState<CustomNodeType>) => s.nodes);
 
   const connections = useNodeConnections({
     handleType: 'target',


### PR DESCRIPTION
1. Removed notes about selector memoization. Selector memoization is no longer needed since Zustand v4:

   - https://github.com/pmndrs/zustand/discussions/387#discussioncomment-3810458

     > Thanks for notifying. We removed the section, because v4 doesn't require it any more.
     > 
     > So, the recommended way is both patterns now:
     > 
     > ```js
     > // this is totally fine.
     > const Component = () => {
     >   const bears = useBearStore(state => state.bears);
     >   // ...
     > };
     > 
     > // this is also fine. (theoretically, this is a little better without relying on JS optimization. But, it's premature optimization and it would be unnecessary for 99.9% of cases.)
     > const selectBears = state => state.bears;
     > const Component = () => {
     >   const bears = useBearStore(selectBears);
     >   // ...
     > };
     > ```

   - https://github.com/pmndrs/zustand/discussions/658

     > In the current implementation, having a stable selector will skip invoking the selector, so it's technically efficient to define a selector outside component. But, yes, it's premature optimization and will not be noticeable in practice.

   - https://github.com/pmndrs/zustand/pull/1707
  
2. Refactored the `useStore` selector function to directly return `s.nodes` instead of wrapping it in an object.

   ```diff
   -const nodes = useStore((s: ReactFlowState<CustomNodeType>) => ({
   -  nodes: s.nodes,
   -}));
   +const nodes = useStore((s: ReactFlowState<CustomNodeType>) => s.nodes);
   ```
   
   The object wrapping is unnecessary when retrieving only one state from the store, and no destructuring syntax is used on the LHS. I think the pattern here is a little misleading.