### PR TITLE
Add missing `center-left` and `center-right` options to Panel documentation

### DIFF
--- a/apps/example-apps/react/learn/panel/App.jsx
+++ b/apps/example-apps/react/learn/panel/App.jsx
@@ -18,6 +18,8 @@ function Flow() {
       <Panel position="bottom-left">bottom-left</Panel>
       <Panel position="bottom-center">bottom-center</Panel>
       <Panel position="bottom-right">bottom-right</Panel>
+      <Panel position="center-left">center-left</Panel>
+      <Panel position="center-right">center-right</Panel>
       <Background variant="cross" />
     </ReactFlow>
   );

--- a/sites/reactflow.dev/src/content/api-reference/components/panel.mdx
+++ b/sites/reactflow.dev/src/content/api-reference/components/panel.mdx
@@ -26,6 +26,8 @@ export default function Flow() {
       <Panel position="bottom-left">bottom-left</Panel>
       <Panel position="bottom-center">bottom-center</Panel>
       <Panel position="bottom-right">bottom-right</Panel>
+      <Panel position="center-left">center-left</Panel>
+      <Panel position="center-right">center-right</Panel>
     </ReactFlow>
   );
 }

--- a/sites/reactflow.dev/src/content/api-reference/types/panel-position.mdx
+++ b/sites/reactflow.dev/src/content/api-reference/types/panel-position.mdx
@@ -21,5 +21,7 @@ export type PanelPosition =
   | 'top-right'
   | 'bottom-left'
   | 'bottom-center'
-  | 'bottom-right';
+  | 'bottom-right'
+  | 'center-left'
+  | 'center-right';
 ```

--- a/sites/svelteflow.dev/src/content/api-reference/components/panel.mdx
+++ b/sites/svelteflow.dev/src/content/api-reference/components/panel.mdx
@@ -30,6 +30,8 @@ components.
   <Panel position="bottom-left">bottom-left</Panel>
   <Panel position="bottom-center">bottom-center</Panel>
   <Panel position="bottom-right">bottom-right</Panel>
+  <Panel position="center-left">center-left</Panel>
+  <Panel position="center-right">center-right</Panel>
 </SvelteFlow>
 ```
 

--- a/sites/svelteflow.dev/src/content/api-reference/types/panel-position.mdx
+++ b/sites/svelteflow.dev/src/content/api-reference/types/panel-position.mdx
@@ -18,7 +18,9 @@ export type PanelPosition =
   | 'top-right'
   | 'bottom-left'
   | 'bottom-center'
-  | 'bottom-right';
+  | 'bottom-right'
+  | 'center-left'
+  | 'center-right';
 ```
 
 ## Fields


### PR DESCRIPTION
### Summary:

Add missing `center-left` and `center-right` options to PanelPosition documentation across React and Svelte to ensure consistency.

### Changes:

- React documentation: Updated Panel component example and PanelPosition type definition to include `center-left` and `center-right` positions
- Svelte documentation: Updated Panel component example and PanelPosition type definition to include `center-left` and `center-right` positions
- React example app: Updated panel example to demonstrate all 8 position options

### Details:

The [PanelPosition](https://github.com/xyflow/xyflow/blob/2d871bd3e687b286cedd6743aac57cfaff9c2371/packages/system/src/types/general.ts#L252) type supports 8 positions total, but the React and Svelte documentation were only showing 6. This PR ensures both React and Svelte documentation consistently document the complete set:

- top-left
- top-center
- top-right
- bottom-left
- bottom-center
- bottom-right
- center-left ✨
- center-right ✨

### Test plan:

- Verified React Panel documentation displays all 8 positions correctly
- Verified Svelte Panel documentation displays all 8 positions correctly
- Verified that the React example app demonstrates the new positions (The Svelte example app already included these positions)


<img width="1440" height="694" alt="Screenshot 2025-09-07 at 11 14 19 PM" src="https://github.com/user-attachments/assets/b8aab634-d6b3-4a55-88b3-c592bc56c719" />


### References:
- Panel Position [TypeScript Type](https://github.com/xyflow/xyflow/blob/2d871bd3e687b286cedd6743aac57cfaff9c2371/packages/system/src/types/general.ts#L252) in xyflow
- CSS Implementation for [Panel](https://github.com/xyflow/xyflow/blob/2d871bd3e687b286cedd6743aac57cfaff9c2371/packages/system/src/styles/init.css#L282) in xyflow