### PR TITLE
Match edge label to the finished flow

### DIFF
--- a/sites/svelteflow.dev/src/content/learn/getting-started/building-a-flow.mdx
+++ b/sites/svelteflow.dev/src/content/learn/getting-started/building-a-flow.mdx
@@ -161,7 +161,7 @@ We change the edge to type `smoothstep` and also give it a label!
 
 ```js
 let edges = $state.raw([
-  { id: 'e1-2', source: '1', target: '2', type: 'smoothstep', label: 'Hello World' },
+  { id: 'e1-2', source: '1', target: '2', type: 'smoothstep', label: 'to the' },
 ]);
 ```
 


### PR DESCRIPTION
This PR sets the sample flow edge label to `to the` instead of `Hello World`, to match the following finished flow visualization.

Currently, it looks like :

<img width="864" height="715" alt="image" src="https://github.com/user-attachments/assets/54dc54e0-94c4-42f1-bcd0-61bb14b5ad14" />
