### PR TITLE
style(node-status-indicator): fix border radius on indicator

### DIFF
--- a/apps/ui-components/registry/components/node-status-indicator/index.tsx
+++ b/apps/ui-components/registry/components/node-status-indicator/index.tsx
@@ -22,11 +22,11 @@ export const SpinnerLoadingIndicator = ({
     <div className="relative">
       <StatusBorder className="border-blue-700/40">{children}</StatusBorder>
 
-      <div className="absolute inset-0 z-50 rounded-[7px] bg-background/50 backdrop-blur-xs" />
+      <div className="bg-background/50 absolute inset-0 z-50 rounded-[9px] backdrop-blur-xs" />
       <div className="absolute inset-0 z-50">
-        <span className="absolute left-[calc(50%-1.25rem)] top-[calc(50%-1.25rem)] inline-block h-10 w-10 animate-ping rounded-full bg-blue-700/20" />
+        <span className="absolute top-[calc(50%-1.25rem)] left-[calc(50%-1.25rem)] inline-block h-10 w-10 animate-ping rounded-full bg-blue-700/20" />
 
-        <LoaderCircle className="absolute left-[calc(50%-0.75rem)] top-[calc(50%-0.75rem)] size-6 animate-spin text-blue-700" />
+        <LoaderCircle className="absolute top-[calc(50%-0.75rem)] left-[calc(50%-0.75rem)] size-6 animate-spin text-blue-700" />
       </div>
     </div>
   );
@@ -39,7 +39,7 @@ export const BorderLoadingIndicator = ({
 }) => {
   return (
     <>
-      <div className="absolute -left-px -top-px h-[calc(100%+2px)] w-[calc(100%+2px)]">
+      <div className="absolute -top-px -left-px h-[calc(100%+2px)] w-[calc(100%+2px)]">
         <style>
           {`
         @keyframes spin {
@@ -57,7 +57,7 @@ export const BorderLoadingIndicator = ({
         }
       `}
         </style>
-        <div className="absolute inset-0 overflow-hidden rounded-[7px]">
+        <div className="absolute inset-0 overflow-hidden rounded-[9px]">
           <div className="spinner rounded-full bg-[conic-gradient(from_0deg_at_50%_50%,rgb(42,67,233)_0deg,rgba(42,138,246,0)_360deg)]" />
         </div>
       </div>
@@ -77,7 +77,7 @@ const StatusBorder = ({
     <>
       <div
         className={cn(
-          "absolute -left-px -top-px h-[calc(100%+2px)] w-[calc(100%+2px)] rounded-[7px] border-2",
+          "absolute -top-px -left-px h-[calc(100%+2px)] w-[calc(100%+2px)] rounded-[9px] border-2",
           className,
         )}
       />


### PR DESCRIPTION
I thought I had more css fixes, but I could only remember this one, the border radius on the node status indicator spinner was off, so I adjusted it. 
 
I was tempted to remove the background color on this panel too, but maybe you all put it in intentionally? 
<img width="528" height="150" alt="Screenshot 2025-10-02 at 13 23 10" src="https://github.com/user-attachments/assets/1a205a33-2b46-40a5-9702-4c2e5a84d75e" />
