### PR TITLE
Refactor edge deletion to use useSvelteFlow

### DIFF
--- a/apps/example-apps/svelte/examples/edges/custom-edges/ButtonEdge.svelte
+++ b/apps/example-apps/svelte/examples/edges/custom-edges/ButtonEdge.svelte
@@ -3,7 +3,7 @@
     getBezierPath,
     BaseEdge,
     type EdgeProps,
-    useEdges,
+    useSvelteFlow,
     EdgeLabel,
   } from '@xyflow/svelte';
 
@@ -30,10 +30,11 @@
     }),
   );
 
-  const edges = useEdges();
+  const { deleteElements } = useSvelteFlow();
 
-  const onEdgeClick = () =>
-    edges.update((eds) => eds.filter((edge) => edge.id !== id));
+  const onEdgeClick = () => {
+    deleteElements({ edges: [{ id }] });
+  }
 </script>
 
 <BaseEdge path={edgePath} {markerEnd} {style} />


### PR DESCRIPTION
This ensures that the `<SvelteFlow>`'s `ondelete` handler is called correctly when an edge is removed.