### PR TITLE
docs: fix typo in custom edge label explanation

### DIFF
--- a/sites/reactflow.dev/src/content/learn/customization/edge-labels.mdx
+++ b/sites/reactflow.dev/src/content/learn/customization/edge-labels.mdx
@@ -9,7 +9,7 @@ import { Image } from 'xy-shared';
 # Edge Labels
 
 One of the more common uses for [custom edges](/learn/customization/custom-edges) is rendering some controls or info
-along an edge's path. In React Flow we call that an _custom edge label_ and unlike the
+along an edge's path. In React Flow we call that a _custom edge label_ and unlike the
 edge path, edge labels can be any React component!
 
 ## Adding an edge label


### PR DESCRIPTION
PR Description

Hi 👋,

While reading the documentation I noticed a small typo in the “Custom Edges / Custom Edge Labels” section.

The original text said:

“In React Flow we call that aN custom edge label…”

I updated it to:

“In React Flow we call that a custom edge label…”

This PR only fixes that grammar issue — no behaviour or logic has been changed.

✔️ What I did

Fixed the “an” → “a” typo in the docs

Ensured the surrounding sentence remains clear and grammatically correct

📌 Why this matters

This improves clarity and correctness for readers following the documentation.

Please let me know if you'd like this change moved to a different page or formatted differently.

Thanks for all your work on React Flow!